### PR TITLE
Revert "expose dns service over tailscale"

### DIFF
--- a/apps/k8s-gateway/service-patch.yaml
+++ b/apps/k8s-gateway/service-patch.yaml
@@ -6,6 +6,5 @@ metadata:
   namespace: kube-system
   annotations:
     coredns.io/hostname: dns
-    tailscale.com/expose: "true"
 spec:
   loadBalancerIP: 192.168.0.53


### PR DESCRIPTION
This reverts commit d7b3a58e2f13e8866e8de5c98f2fd2903398cdbf.