### PR TITLE
feat: add hermes app with read-only RBAC

### DIFF
--- a/apps/hermes/kustomization.yaml
+++ b/apps/hermes/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hermes
+
+resources:
+  - rbac.yaml

--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -23,6 +23,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -1,0 +1,129 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - endpoints
+      - events
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - ciliumendpoints
+      - ciliumidentities
+      - ciliumnetworkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-agent
+subjects:
+  - kind: ServiceAccount
+    name: hermes-agent
+    namespace: hermes

--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -7,8 +7,6 @@ rules:
       - ""
     resources:
       - namespaces
-      - pods
-      - pods/log
       - services
       - configmaps
       - endpoints

--- a/argocd/apps/hermes.yaml
+++ b/argocd/apps/hermes.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hermes
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  destination:
+    namespace: hermes
+    server: https://kubernetes.default.svc
+  source:
+    path: apps/hermes
+    repoURL: https://github.com/gedulis12/homelab
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds a new `hermes` app to the homelab with:

- **Namespace:** `hermes`
- **** — `ClusterRole` (`hermes-agent`) with read-only access across core, apps, batch, networking, RBAC, gateway, cilium, and metrics resources
- **** — binds the role to `ServiceAccount:hermes-agent` in namespace `hermes`
- **ArgoCD Application** — standard pattern matching other apps in the repo

All rules are strictly `get`, `list`, `watch` — no write permissions.