### PR TITLE
enable kubernetes api server access over tailscale

### DIFF
--- a/apps/tailscale/values.yaml
+++ b/apps/tailscale/values.yaml
@@ -6,3 +6,6 @@ oauth:
 oauthSecretVolume:
   secret:
     secretName: tailscale-operator-oauth
+
+apiServerProxyConfig:
+  mode: "true"


### PR DESCRIPTION
## Summary

- Enables the Tailscale operator's in-process API server proxy (`apiServerProxyConfig.mode: "true"`) so the cluster's `kube-apiserver` is reachable over the tailnet instead of only the local network, per [Tailscale's Kubernetes API server access docs](https://tailscale.com/docs/kubernetes-operator/api-server-access).
- Runs in **auth mode**: the proxy impersonates the caller's Tailscale identity (user login or tagged device FQDN) when forwarding to the API server. Kubernetes RBAC still fully applies — reaching the proxy grants no permissions by itself.
- Single-replica, no new resources — this piggybacks on the existing operator deployment (no dedicated `ProxyGroup`).

## Required manual steps (not tracked in this repo)

This repo doesn't check in a Tailscale ACL policy file, so the following need to be applied via the [Tailscale admin console](https://login.tailscale.com/admin/acls) ACL editor after this PR merges:

1. Allow the relevant tailnet devices/users to reach the proxy on port 443:
   ```json
   "grants": [
     {
       "src": ["autogroup:member"],
       "dst": ["tag:k8s-operator"],
       "ip": ["tcp:443"]
     }
   ]
   ```
   Replace `autogroup:member` with a narrower group/tag if you want to restrict who can reach the proxy.

2. Grant Kubernetes RBAC permissions to the identities that should have access, e.g.:
   ```bash
   kubectl create clusterrolebinding my-user-view \
     --user="<your-tailnet-email>" \
     --clusterrole=view
   ```

## Test plan

- [ ] `kubectl apply` / ArgoCD sync picks up the updated `values.yaml` and the operator Deployment gains the `APISERVER_PROXY` env var / RBAC for the API server proxy
- [ ] Apply the ACL grant above in the admin console
- [ ] Run `tailscale configure kubeconfig <tailscale-operator-hostname>` from a tailnet device and confirm `kubectl get pods` (or similar) works against the cluster
- [ ] Confirm requests without a matching ClusterRoleBinding are denied (RBAC still enforced)