### PR TITLE
fix: use OIDC Group subject for RBAC binding

### DIFF
--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -132,6 +132,6 @@ roleRef:
   kind: ClusterRole
   name: hermes-agent
 subjects:
-  - kind: ServiceAccount
-    name: hermes-agent
-    namespace: hermes
+  - kind: Group
+    name: tag:hermes-agent
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Changed the ClusterRoleBinding subject from `ServiceAccount:hermes-agent` in namespace `hermes` to `Group:tag:hermes-agent` — binds the Tailscale-tagged node directly via OIDC group.