### PR TITLE
feat: hermes-agent RBAC with hermes-agents group

### DIFF
--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -133,5 +133,5 @@ roleRef:
   name: hermes-agent
 subjects:
   - kind: Group
-    name: tag:hermes-agent
+    name: hermes-agents
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Updates the ClusterRoleBinding to use `hermes-agents` OIDC group to match the Tailscale ACL impersonation config. Depends on PR #231 (API server proxy) being merged/synced.