### PR TITLE
feat: create Grafana service account hermes-agent with Editor role

### DIFF
--- a/apps/observability/grafana-resources/kustomization.yaml
+++ b/apps/observability/grafana-resources/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - contactpoints.yaml
   - notification-policies.yaml
   - datasources.yaml
+  - service-account.yaml
   - monitoring-mixins
   - dashboards

--- a/apps/observability/grafana-resources/service-account.yaml
+++ b/apps/observability/grafana-resources/service-account.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaServiceAccount
+metadata:
+  name: hermes-agent
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  role: Editor
+  name: hermes-agent

--- a/apps/observability/grafana-resources/service-account.yaml
+++ b/apps/observability/grafana-resources/service-account.yaml
@@ -4,8 +4,9 @@ kind: GrafanaServiceAccount
 metadata:
   name: hermes-agent
 spec:
-  instanceSelector:
-    matchLabels:
-      dashboards: grafana
-  role: Editor
   name: hermes-agent
+  instanceName: grafana
+  role: Editor
+  isDisabled: false
+  tokens:
+    - name: hermes-agent-token


### PR DESCRIPTION
Creates a `GrafanaServiceAccount` resource via the Grafana operator named `hermes-agent` with `Editor` role, provisioned alongside the other grafana-resources.