### PR TITLE
feat: add pods/exec and pods/portforward create permissions

### DIFF
--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -8,11 +8,14 @@ rules:
     resources:
       - pods
       - pods/log
+      - pods/exec
+      - pods/portforward
     verbs:
       - get
       - list
       - watch
       - delete
+      - create
   - apiGroups:
       - "*"
     resources:


### PR DESCRIPTION
Adds create verb for pods/exec and pods/portforward subresources so cilium CLI and hubble CLI can run kubectl exec and port-forward for network observability.