### PR TITLE
fix: raise maistokainos postgres shared_buffers/work_mem

### DIFF
--- a/apps/maistokainos/cloudnative-pg.yaml
+++ b/apps/maistokainos/cloudnative-pg.yaml
@@ -9,6 +9,15 @@ spec:
       k8s.grafana.com/scrape: "true"
       k8s.grafana.com/metrics.portName: metrics
   instances: 1
+  postgresql:
+    parameters:
+      shared_buffers: "512MB"
+      work_mem: "64MB"
+      effective_cache_size: "1536MB"
+  resources:
+    requests:
+      memory: "768Mi"
+      cpu: "250m"
   storage:
     pvcTemplate:
       storageClassName: ""


### PR DESCRIPTION
## Summary
- Production has been failing to refresh the aggregate cache every ~10-11 min (`failed to refresh aggregates ... build deals: failed to get price drops: timeout: context deadline exceeded`). Root cause investigation (see maistokainos.lt repo) traced it to a combination of an inefficient median query and severely undersized Postgres memory settings for a 35M-row table living on NFS-backed storage.
- The query itself is being fixed separately in the app repo (avoids full-table scans, computes the median once instead of twice).
- This PR addresses the DB-tuning half: `shared_buffers` and `work_mem` are currently stock defaults (128MB / 4MB), which forces disk-spilled sorts/hashes and repeated cold reads over NFS for a working set that's only a few hundred MB. Raising these lets the ~30-day working set stay resident across the 10-minute rebuild cycle instead of re-fetching over NFS every time.
- Also adds a `resources.requests` (no `limits`) so the pod gets scheduling priority on the shared node without hard-capping its memory.

## Changes
- `apps/maistokainos/cloudnative-pg.yaml`:
  - `postgresql.parameters`: `shared_buffers: 512MB`, `work_mem: 64MB`, `effective_cache_size: 1536MB`
  - `resources.requests`: `memory: 768Mi`, `cpu: 250m` (no limits set)

## Test plan
- [ ] `shared_buffers` requires a Postgres restart — since `instances: 1`, applying this will cause a brief rolling restart of the single postgres pod. Apply during a low-traffic window.
- [ ] After rollout, confirm the pod picks up the new settings: `SHOW shared_buffers; SHOW work_mem;`
- [ ] Confirm `failed to refresh aggregates` errors stop recurring in app logs after the corresponding query fix ships.
- [ ] Watch node memory pressure on the shared Pi node for a day to make sure the new request doesn't cause scheduling issues for co-located pods.