### PR TITLE
feat: optimize maistokainos NFS mount options

### DIFF
--- a/apps/maistokainos/pvc.yaml
+++ b/apps/maistokainos/pvc.yaml
@@ -32,11 +32,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2


### PR DESCRIPTION
## Summary

Optimizes the NFS mount options for the maistokainos PVC. The NFS server (192.168.0.222) is the same machine as the pod's node (n200), making this a loopback mount.

## Changes

| Removed | Reason |
|---------|--------|
| `rsize=8192` / `wsize=8192` | Constrained to ~0.8% of default (1 MB). Kernel auto-negotiates optimal size |
| `vers=3` | Auto-detected |
| `tcp` | Default protocol |
| `lookupcache=none` | Unnecessary for single-writer — default (`all`) caches properly |
| `soft` | Unsafe for writes — replaced with `hard` |
| `retrans=5` | Overkill on local network — default (2) is sufficient |

## Kept

- `noatime` — reduces write traffic
- `timeo=600` — reasonable timeout

## Verification

- [x] PVC YAML validates correctly
- [x] ArgoCD will pick up the change on sync