### PR TITLE
fix: revert effective_cache_size override, let it default

### DIFF
--- a/apps/maistokainos/cloudnative-pg.yaml
+++ b/apps/maistokainos/cloudnative-pg.yaml
@@ -13,7 +13,6 @@ spec:
     parameters:
       shared_buffers: "512MB"
       work_mem: "64MB"
-      effective_cache_size: "1536MB"
   resources:
     requests:
       memory: "768Mi"


### PR DESCRIPTION
## Summary
- Follow-up to #239. That PR set `effective_cache_size: "1536MB"` alongside the `shared_buffers`/`work_mem` bump.
- Researched actual defaults: vanilla PostgreSQL 17's compiled-in default for `effective_cache_size` is **4GB**, and CNPG does not auto-tune memory GUCs based on pod resources under any condition (confirmed via CNPG docs and a closed "not planned" feature request for dynamic tuning). So this cluster was silently running at the 4GB default before #239 — my explicit 1536MB was a ~62% cut.
- Verified impact via `EXPLAIN ANALYZE` against prod: with the lower value, the query planner abandoned the index-based nested-loop plan (validated separately in the app-repo fix) and fell back to a full sequential scan of the 35M-row `pricehistory` table + disk-spilled sort, taking ~122s — actively worse for the exact problem #239 was meant to help with.

## Changes
- `apps/maistokainos/cloudnative-pg.yaml`: remove the `effective_cache_size` override so it falls back to Postgres's own 4GB default. `shared_buffers`/`work_mem` increases from #239 are kept.

## Test plan
- [ ] After rollout (no restart needed — `effective_cache_size` is reloadable, not a restart-required GUC), confirm: `SHOW effective_cache_size;` reports `4GB`.
- [ ] Re-run `EXPLAIN ANALYZE` on the deals/hikes median query and confirm the planner picks the index-based nested-loop plan again (no `Seq Scan` on `pricehistory`).