### PR TITLE
feat: optimize NFS mount options across all apps

### DIFF
--- a/apps/authentik/cloudnative-pg.yaml
+++ b/apps/authentik/cloudnative-pg.yaml
@@ -46,11 +46,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/freshrss/pvc.yaml
+++ b/apps/freshrss/pvc.yaml
@@ -34,11 +34,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/immich/cloudnative-pg.yaml
+++ b/apps/immich/cloudnative-pg.yaml
@@ -48,11 +48,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/immich/pvc.yaml
+++ b/apps/immich/pvc.yaml
@@ -34,12 +34,7 @@ spec:
     server: 192.168.0.135
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - nolock
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/linkding/pvc.yaml
+++ b/apps/linkding/pvc.yaml
@@ -34,11 +34,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/maistokainos/cloudnative-pg.yaml
+++ b/apps/maistokainos/cloudnative-pg.yaml
@@ -48,11 +48,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/media/jellyfin/pvc.yaml
+++ b/apps/media/jellyfin/pvc.yaml
@@ -36,11 +36,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/media/prowlarr/pvc.yaml
+++ b/apps/media/prowlarr/pvc.yaml
@@ -36,11 +36,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/media/pvc.yaml
+++ b/apps/media/pvc.yaml
@@ -32,11 +32,6 @@ spec:
     server: 192.168.0.135
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/media/qbittorrent/pvc.yaml
+++ b/apps/media/qbittorrent/pvc.yaml
@@ -36,11 +36,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/media/radarr/pvc.yaml
+++ b/apps/media/radarr/pvc.yaml
@@ -36,11 +36,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/media/sonarr/pvc.yaml
+++ b/apps/media/sonarr/pvc.yaml
@@ -36,11 +36,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/observability/grafana/pvc.yaml
+++ b/apps/observability/grafana/pvc.yaml
@@ -36,11 +36,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/observability/loki/pvc.yaml
+++ b/apps/observability/loki/pvc.yaml
@@ -32,11 +32,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/observability/prometheus/pvc.yaml
+++ b/apps/observability/prometheus/pvc.yaml
@@ -18,14 +18,9 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2
 
 ---
 apiVersion: v1
@@ -61,11 +56,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/observability/pyroscope/pvc.yaml
+++ b/apps/observability/pyroscope/pvc.yaml
@@ -32,11 +32,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/observability/tempo/pvc.yaml
+++ b/apps/observability/tempo/pvc.yaml
@@ -32,11 +32,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/thelounge/pvc.yaml
+++ b/apps/thelounge/pvc.yaml
@@ -34,11 +34,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2

--- a/apps/wallabag/pvc.yaml
+++ b/apps/wallabag/pvc.yaml
@@ -34,14 +34,9 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2
 
 ---
 apiVersion: v1
@@ -81,11 +76,6 @@ spec:
     server: 192.168.0.222
   mountOptions:
     - noatime
-    - vers=3
-    - soft
+    - hard
     - timeo=600
-    - retrans=5
-    - rsize=8192
-    - wsize=8192
-    - lookupcache=none
-    - tcp
+    - retrans=2


### PR DESCRIPTION
## Summary

Consolidates the NFS mount option optimization from #240 across **all 19 PVC/PV files** in the repo (21 PVs total). Every PV was using the same stale template with aggressively conservative settings.

## Scope

| Files changed | PVs updated | NFS servers |
|:---|---:|:---|
| 19 | 21 | 192.168.0.222 (loopback), 192.168.0.135 (media) |

## Changes per PV

| Removed | Reason |
|---------|--------|
| `rsize=8192` / `wsize=8192` | Constrained throughput to ~0.8% of kernel default (1 MB) |
| `vers=3` | Auto-detected |
| `tcp` | Default protocol |
| `lookupcache=none` | Unnecessary for single-writer — default (`all`) caches properly |
| `soft` | Unsafe for writes — replaced with `hard` |
| `retrans=5 → 2` | Overkill on local network — default is sufficient |

| Kept | Reason |
|------|--------|
| `noatime` | Reduces write traffic |
| `timeo=600` | Reasonable timeout |
| `nolock` | Kept on `immich-library` (NFS server doesn't support locking) |

## Files

- `apps/wallabag/pvc.yaml` — 2 PVs (data + images)
- `apps/thelounge/pvc.yaml`
- `apps/freshrss/pvc.yaml`
- `apps/linkding/pvc.yaml`
- `apps/media/pvc.yaml`
- `apps/media/sonarr/pvc.yaml`
- `apps/media/radarr/pvc.yaml`
- `apps/media/prowlarr/pvc.yaml`
- `apps/media/qbittorrent/pvc.yaml`
- `apps/media/jellyfin/pvc.yaml`
- `apps/immich/pvc.yaml` (has `nolock`)
- `apps/immich/cloudnative-pg.yaml`
- `apps/authentik/cloudnative-pg.yaml`
- `apps/maistokainos/cloudnative-pg.yaml`
- `apps/observability/prometheus/pvc.yaml` — 2 PVs
- `apps/observability/grafana/pvc.yaml`
- `apps/observability/loki/pvc.yaml`
- `apps/observability/tempo/pvc.yaml`
- `apps/observability/pyroscope/pvc.yaml`

## Verification

- [x] `git diff --stat`: 42 insertions, 147 deletions across 19 files
- [x] All PVs use same cleaned-up options
- [x] `immich-library` retains `nolock` (server-specific requirement)