### PR TITLE
fix: use correct CNPG field additionalPodAffinity

### DIFF
--- a/apps/maistokainos/cloudnative-pg.yaml
+++ b/apps/maistokainos/cloudnative-pg.yaml
@@ -10,7 +10,7 @@ spec:
       k8s.grafana.com/metrics.portName: metrics
   instances: 1
   affinity:
-    podAffinity:
+    additionalPodAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:


### PR DESCRIPTION
## Fixes PR #243

PR #243 used `affinity.podAffinity` which is **silently ignored** by the CloudNative-PG operator — the CRD schema doesn't accept it.

CNPG exposes pod affinity via `affinity.additionalPodAffinity` with the same nested structure:

```yaml
affinity:
  additionalPodAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
            - key: app
              operator: In
              values:
                - maistokainos
        topologyKey: kubernetes.io/hostname
```

This 1-line fix changes `podAffinity` → `additionalPodAffinity`.