### PR TITLE
feat: bump maistokainos tag to v0.0.15

### DIFF
--- a/apps/maistokainos/deployment.yaml
+++ b/apps/maistokainos/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         kubernetes.io/hostname: n200
       containers:
         - name: maistokainos
-          image: gedulis12/maistokainos.lt:0.0.14
+          image: gedulis12/maistokainos.lt:0.0.15
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Update maistokainos.lt image tag from `0.0.14` to `0.0.15`.