### PR TITLE
fix: set prometheusType so recording rules remote-write to the right path

### DIFF
--- a/apps/observability/grafana-resources/datasources.yaml
+++ b/apps/observability/grafana-resources/datasources.yaml
@@ -17,6 +17,14 @@ spec:
     uid: prometheus-main
     jsonData:
       "timeInterval": "60s"
+      # Grafana's recording-rule remote-write path selection reads this field
+      # (pkg/services/ngalert/writer/datasourcewriter.go getRemoteWriteURL) to
+      # decide between Prometheus's /api/v1/write and a Mimir/Cortex-style
+      # /api/v1/push path. Normally auto-detected by the UI's "Save & Test"
+      # buildinfo probe, which never runs for CR-provisioned datasources, so
+      # recording rules remote-write 404 (hitting a push path that doesn't
+      # exist on plain Prometheus) unless set explicitly.
+      "prometheusType": "Prometheus"
 
 ---
 apiVersion: grafana.integreatly.org/v1beta1


### PR DESCRIPTION
## Summary
After #246 merged, native recording rules were still failing to evaluate:

```
remote write failed: failed to write time series
expected HTTP 200 status code: actual=404, body=404 page not found
```

Root-caused by reading Grafana's actual writer source
(`pkg/services/ngalert/writer/datasourcewriter.go`, `getRemoteWriteURL`):
it only builds the correct `/api/v1/write` path when the datasource's
`jsonData.prometheusType` is exactly `"Prometheus"`. Without it, Grafana
assumes the target is Mimir/Cortex and builds a `/api/v1/push`-style path
instead — which doesn't exist on plain Prometheus, hence the 404.

This field is normally auto-detected by the datasource UI's "Save & Test"
buildinfo probe, which never runs for CR-provisioned datasources — so it
silently stayed unset. Setting it explicitly on `prometheus-main` fixes
the remote-write path.

Confirmed via `gcx alert rules list`/`get` (health=error, lastError showing
the 404) and Grafana pod logs before the fix.

## Test plan
- [ ] Apply/sync and confirm `gcx alert rules list -o json | jq '.[] | .rules[]? | select(.type=="recording")'` shows `health: ok` instead of `error`.
- [ ] Confirm a recorded metric (e.g. `instance:node_num_cpu:sum`) is queryable in Prometheus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)