### PR TITLE
Add ignoreDifferences for Gateway API server-defaulted fields

### DIFF
--- a/argocd/apps/cilium.yaml
+++ b/argocd/apps/cilium.yaml
@@ -15,6 +15,23 @@ spec:
     path: apps/cilium
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      jsonPointers:
+        - /spec/listeners/0/allowedRoutes
+        - /spec/listeners/1/allowedRoutes
+        - /spec/listeners/1/tls/certificateRefs/0/group
+        - /spec/listeners/1/tls/certificateRefs/0/kind
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true

--- a/argocd/apps/grafana.yaml
+++ b/argocd/apps/grafana.yaml
@@ -15,6 +15,13 @@ spec:
     path: apps/observability/grafana
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true

--- a/argocd/apps/prometheus.yaml
+++ b/argocd/apps/prometheus.yaml
@@ -15,6 +15,13 @@ spec:
     path: apps/observability/prometheus
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
Adds `ignoreDifferences` to the cilium, grafana, and prometheus ArgoCD Applications to suppress false-positive OutOfSync on Gateway and HTTPRoute resources.

The Gateway API controller adds default fields on resource creation (`group`, `kind`, `weight: 1`, `matches` on redirect routes) that ArgoCD currently flags as drift. These are semantically identical — the ignored fields don't change behaviour.

See PR #247 for context — these were the same OutOfSync resources reported after the observability app split.