### PR TITLE
Add backendRefs group/kind/weight to ignoreDifferences

### DIFF
--- a/argocd/apps/grafana.yaml
+++ b/argocd/apps/grafana.yaml
@@ -21,6 +21,9 @@ spec:
       jsonPointers:
         - /spec/parentRefs/0/group
         - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
         - /spec/rules/0/matches
   syncPolicy:
     automated:

--- a/argocd/apps/prometheus.yaml
+++ b/argocd/apps/prometheus.yaml
@@ -21,6 +21,9 @@ spec:
       jsonPointers:
         - /spec/parentRefs/0/group
         - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
         - /spec/rules/0/matches
   syncPolicy:
     automated:


### PR DESCRIPTION
Follow-up to PR #250 — the `backendRefs[0].group`, `backendRefs[0].kind`, and `backendRefs[0].weight` fields are also defaulted by the Gateway API controller on HTTPRoutes created by the grafana and kube-prometheus-stack Helm charts.

Prometheus was still showing OutOfSync on `HTTPRoute/kube-prometheus-stack-prometheus` because these fields weren't in the ignore list.