### PR TITLE
fix: enable proxy mode in itarmy startup

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
                 /opt/itarmykit-headless/kit-headless-supervisor identity set-api-key "$API_KEY"
                 /opt/itarmykit-headless/kit-headless-supervisor identity opt-in 1
               fi
+              /opt/itarmykit-headless/kit-headless-supervisor settings set proxy 1
               exec /opt/itarmykit-headless/kit-headless-supervisor run
           env:
             - name: KIT_CPU_LIMIT_PERCENT


### PR DESCRIPTION
Adds `settings set proxy 1` to the DaemonSet startup script so the kit uses auto routing (Layer7 HTTP proxy from feed lists) instead of direct connections only.

See https://itarmy.com.ua/kit-instructions/?lang=en#proxy