### PR TITLE
fix: set CPU/bandwidth limits via CLI at startup

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -32,12 +32,10 @@ spec:
                 /opt/itarmykit-headless/kit-headless-supervisor identity opt-in 1
               fi
               /opt/itarmykit-headless/kit-headless-supervisor settings set proxy 1
+              /opt/itarmykit-headless/kit-headless-supervisor settings set cpuLimitPercent 30
+              /opt/itarmykit-headless/kit-headless-supervisor settings set bandwidthLimitMbps 100
               exec /opt/itarmykit-headless/kit-headless-supervisor run
           env:
-            - name: KIT_CPU_LIMIT_PERCENT
-              value: "30"
-            - name: KIT_BANDWIDTH_LIMIT_MBPS
-              value: "100"
             - name: PARTICIPANT_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The env vars `KIT_CPU_LIMIT_PERCENT` and `KIT_BANDWIDTH_LIMIT_MBPS` aren't picked up by the supervisor when the `command` is overridden with a shell script. Instead, we now write all three settings explicitly via `settings set` before running the supervisor:

- `settings set proxy 1`
- `settings set cpuLimitPercent $KIT_CPU_LIMIT_PERCENT`
- `settings set bandwidthLimitMbps $KIT_BANDWIDTH_LIMIT_MBPS`

Also keeps the `KIT_*` env vars as documentation / future-proofing.