### PR TITLE
feat: run itarmy with privileged mode and enableSyn

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -34,7 +34,10 @@ spec:
               /opt/itarmykit-headless/kit-headless-supervisor settings set proxy 1
               /opt/itarmykit-headless/kit-headless-supervisor settings set cpuLimitPercent 30
               /opt/itarmykit-headless/kit-headless-supervisor settings set bandwidthLimitMbps 100
+              /opt/itarmykit-headless/kit-headless-supervisor settings set enableSyn 1
               exec /opt/itarmykit-headless/kit-headless-supervisor run
+          securityContext:
+            privileged: true
           env:
             - name: PARTICIPANT_ID
               valueFrom:


### PR DESCRIPTION
Two changes to itarmy DaemonSet:

- **`securityContext.privileged: true`** — needed for raw socket access (SYN flood attacks)
- **`settings set enableSyn 1`** — enables SYN flood capability in the kit