### PR TITLE
fix: run itarmy as root to keep effective capabilities

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -38,6 +38,7 @@ spec:
               exec /opt/itarmykit-headless/kit-headless-supervisor run
           securityContext:
             privileged: true
+            runAsUser: 0
           env:
             - name: PARTICIPANT_ID
               valueFrom:


### PR DESCRIPTION
The container image runs as non-root uid 1001 (`itarmykit-headless`), which means `privileged: true` alone is not enough — `CapEff` is 0 and the process has no effective capabilities.

Adding `runAsUser: 0` forces the container to run as root so `privileged: true` actually grants all capabilities including `CAP_NET_RAW` needed for SYN flood.