### PR TITLE
hermes-agent: add delete jobs permission to ClusterRole

### DIFF
--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -21,6 +21,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adds `batch/jobs` with `delete` verb to the hermes-agent ClusterRole, so the oncall agent can clean up stale failed jobs that trigger alerts like KubeJobFailed.

Previously the agent had `delete` only on pods — this extends it to jobs.