### PR TITLE
feat: add hostPath volume for itarmy data persistence

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -18,6 +18,11 @@ spec:
         kubernetes.io/os: linux
       tolerations:
         - operator: Exists
+      volumes:
+        - name: itarmy-data
+          hostPath:
+            path: /opt/itarmykit/
+            type: DirectoryOrCreate
       containers:
         - name: itarmykit
           image: registry.download.itarmy.com.ua/itarmykit-headless:2.2.8
@@ -36,6 +41,9 @@ spec:
               /opt/itarmykit-headless/kit-headless-supervisor settings set bandwidthLimitMbps 100
               /opt/itarmykit-headless/kit-headless-supervisor settings set enableSyn 1
               exec /opt/itarmykit-headless/kit-headless-supervisor run
+          volumeMounts:
+            - name: itarmy-data
+              mountPath: /var/lib/itarmykit-headless/
           securityContext:
             privileged: true
             runAsUser: 0


### PR DESCRIPTION
Adds a `hostPath` volume mounting `/var/lib/itarmykit-headless/` (the data dir) onto host path `/opt/itarmykit/` with `DirectoryOrCreate`.

**Why:** Without a persistent volume, deleting an IT Army pod (DaemonSet update, node drain, manual delete) loses all locally accumulated state — identity, telemetry checkpoints, proxy pair cache, un-uploaded stats. With hostPath, each node keeps its own pod's data across restarts.

**What survives:**
- `identity.json` / identity backup
- `telemetry-upload-session.json` (server-confirmed credited bytes)
- `telemetry-period-seq.json` (upload sequence state)
- `telemetry-upload-retry-outbox.json` (pending retries)
- `stability.log` / `stability.log.1` (un-uploaded period data)
- `pair-store-snapshot.json` (proxy pair cache — avoids rediscovery delay on restart)

**Per-node isolation:** hostPath is node-local, which is correct for a DaemonSet — each node's data stays on that node.