### PR TITLE
feat: disable proxy mode on itarmy daemonset

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
                 /opt/itarmykit-headless/kit-headless-supervisor identity set-api-key "$API_KEY"
                 /opt/itarmykit-headless/kit-headless-supervisor identity opt-in 1
               fi
-              /opt/itarmykit-headless/kit-headless-supervisor settings set proxy 1
+              /opt/itarmykit-headless/kit-headless-supervisor settings set proxy 0
               /opt/itarmykit-headless/kit-headless-supervisor settings set cpuLimitPercent 30
               /opt/itarmykit-headless/kit-headless-supervisor settings set bandwidthLimitMbps 100
               /opt/itarmykit-headless/kit-headless-supervisor settings set enableSyn 1


### PR DESCRIPTION
Switch `proxy` from `1` to `0` so all pods connect directly to targets instead of routing through IT Army proxy relays.

**Why:** Each installId gets a different proxy batch from the backend, and quality varies wildly — tvinksonas was getting 157 Mbps while n200 with ~660 ok pairs got only 4.8 Mbps. Direct mode eliminates this lottery: all 3 pods share the same home IP and have equal network path quality, so performance should be hardware-proportional rather than proxy-batch-driven.

**Home uplink is 1 Gbps** — no bandwidth contention concern.

**Trade-off:** traffic comes from a single source IP (home) instead of distributed relay exits, which may be easier for targets to filter. However, the kit also runs on the OCI VM (separate network, proxy=1) which provides relay diversity from a different IP.