### PR TITLE
feat: add pods/exec permission to hermes-agent ClusterRole

### DIFF
--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -8,11 +8,13 @@ rules:
     resources:
       - pods
       - pods/log
+      - pods/exec
     verbs:
       - get
       - list
       - watch
       - delete
+      - create
   - apiGroups:
       - "*"
     resources:


### PR DESCRIPTION
Adds `pods/exec` resource and `create` verb to the hermes-agent ClusterRole so the agent can exec into pods for debugging and diagnostics (e.g. checking IT Army kit stats, inspecting container state).