### PR TITLE
fix: add hostAliases to argocd-server for auth.g2net.xyz DNS resolution

### DIFF
--- a/argocd/dns-patch.yaml
+++ b/argocd/dns-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+spec:
+  template:
+    spec:
+      hostAliases:
+        - ip: "192.168.0.51"
+          hostnames:
+            - "auth.g2net.xyz"

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -49,3 +49,8 @@ patches:
       name: argocd-cmd-params-cm
       version: v1
     path: tls-patch.yaml
+  - target:
+      kind: Deployment
+      name: argocd-server
+      version: v1
+    path: dns-patch.yaml


### PR DESCRIPTION
## Summary

The OIDC issuer `https://auth.g2net.xyz` resolves to a local IP (`192.168.0.51`) that cluster DNS (CoreDNS) can't reach, causing the SSO login to fail with `no such host`.

### Fix

Adds `hostAliases` to the argocd-server Deployment (same pattern as Grafanas existing `hostAliases` entry) so `auth.g2net.xyz` is resolved locally via `/etc/hosts`.

### Changes

- **`argocd/dns-patch.yaml`** — Strategic merge patch adding hostAliases to argocd-server
- **`argocd/kustomization.yaml`** — Wire in the new patch