### PR TITLE
fix: correct Authentik OIDC issuer slug to argo-cd

### DIFF
--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -26,7 +26,7 @@ patches:
         path: /data/oidc.config
         value: |
           name: Authentik
-          issuer: https://auth.g2net.xyz/application/o/argocd/
+          issuer: https://auth.g2net.xyz/application/o/argo-cd/
           clientID: $argocd-oidc-secret:client-id
           clientSecret: $argocd-oidc-secret:client-secret
           requestedScopes: ["openid", "profile", "email", "entitlements"]


### PR DESCRIPTION
The Authentik application slug is `argo-cd` but the issuer URL was `argocd`, causing a 404 when ArgoCD tries to fetch the OIDC configuration. One-character fix.