### PR TITLE
fix: replace extraVolumeMounts/extraVolumes with dataVolumeParameters for Loki PVC

### DIFF
--- a/apps/observability/loki/values.yaml
+++ b/apps/observability/loki/values.yaml
@@ -64,13 +64,9 @@ singleBinary:
   replicas: 1
   persistence:
     enabled: false
-  extraVolumeMounts:
-    - name: storage
-      mountPath: /var/loki
-  extraVolumes:
-    - name: storage
-      persistentVolumeClaim:
-        claimName: loki-pvc
+  dataVolumeParameters:
+    persistentVolumeClaim:
+      claimName: loki-pvc
 
 backend:
   replicas: 0


### PR DESCRIPTION
## Problem

After the chart migration to grafana-community/loki v18.4.4, ArgoCD fails to sync the loki StatefulSet:

```
.spec.template.spec.volumes: duplicate entries for key [name="storage"]
.spec.template.spec.containers[name="loki"].volumeMounts: duplicate entries for key [mountPath="/var/loki"]
```

**Root cause:** The new chart already creates a \`storage\` volume and mounts it at \`/var/loki\` by default (backed by emptyDir when \`persistence.enabled: false\`). The old chart did not, so \`extraVolumeMounts\` + \`extraVolumes\` were needed — now they collide with the chart's built-in ones.

## Fix

Replaced the manual \`extraVolumeMounts\`/\`extraVolumes\` with \`dataVolumeParameters\`, which tells the chart to swap its default emptyDir for the existing \`loki-pvc\` PVC — no duplicate, no conflict.