### PR TITLE
fix: remove loki.ui config — UI no longer bundled in Loki 3.7.x

### DIFF
--- a/apps/observability/loki/values.yaml
+++ b/apps/observability/loki/values.yaml
@@ -1,9 +1,5 @@
 ---
 loki:
-  ui:
-    enabled: true
-    gateway:
-      enabled: true
   commonConfig:
     replication_factor: 1
   schemaConfig:


### PR DESCRIPTION
## Problem

`loki.g2net.xyz/ui` returns an infinite 307 redirect loop to `/ui/404?path=/ui`.

## Root Cause

Loki Helm chart **6.43.0** (PR [#19390](https://github.com/grafana/loki/pull/19390)) removed the embedded web UI from Loki. It was moved to a [Grafana plugin](https://github.com/grafana/loki-operational-ui).

The `loki.ui.enabled: true` flag only added `-target=ui` to Loki's args (which enables backend APIs for the Grafana plugin) and generated nginx `/ui` routing — but Loki itself returns 307 redirects to `/ui/404` for any UI path, since the SPA assets are no longer in the binary.

## Fix

Removed the stale `loki.ui` config block. Loki continues to serve all API endpoints normally (`/loki/api/v1/...`, `/ready`, `/metrics`).

To get the Loki UI back, install the [grafana-lokiexplore-app](https://github.com/grafana/loki-operational-ui) plugin in Grafana, or use Grafana Explore with the Loki datasource.