### PR TITLE
fix: add ArgoCD ignoreDifferences for Loki HTTPRoute

### DIFF
--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Summary

Loki's HTTPRoute (`loki-gateway`) is OutOfSync because the Cilium Gateway controller normalizes the `parentRefs` field — adding `group`, `kind`, `namespace`, and `sectionName` — which ArgoCD detects as a diff.

### Fix

Added the same `ignoreDifferences` rules for HTTPRoute that **Grafana** and **Prometheus** already have in their Application YAMLs (`argocd/apps/grafana.yaml`, `argocd/apps/prometheus.yaml`). These skip the auto-populated fields:

- `/spec/parentRefs/0/group`
- `/spec/parentRefs/0/kind`
- `/spec/rules/0/backendRefs/0/group`
- `/spec/rules/0/backendRefs/0/kind`
- `/spec/rules/0/backendRefs/0/weight`
- `/spec/rules/0/matches`

### Verification

- Only the `HTTPRoute/loki-gateway` was OutOfSync (all other Loki resources Healthy/Synced)
- This is the same pattern already proven on Grafana and Prometheus apps