### PR TITLE
chore: upgrade k8s-monitoring-helm chart to 3.8.10

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml


### PR DESCRIPTION
## Summary

Upgrades the `k8s-monitoring-helm` chart from 3.8.7 → 3.8.10.

### Changes included (3.8.8 → 3.8.10)

**3.8.8**
- Dependency bumps only — no feature changes.

**3.8.9**
- Bump Alloy Operator to 0.5.8, OpenCost to 2.5.22, Windows Exporter to 0.12.7
- Add `timeout` setting on OTLP destination (optional)
- Add WAL support on Loki destination (optional)
- Fix `spanMetrics.excludeDimensions` rendering for Alloy compatibility
- Clear error when `profiling.enabled: true` but no profiling type is selected
- Remove unsupported `scrape_protocols` from Prometheus Operator Objects
- Auto-prepend `PrometheusProto` scrape protocol when native histograms enabled

**3.8.10**
- **Bug fix**: OTLP destination `timeout` now renders inside the `client` block (fixes Alloy 1.16.3+ rejection of misplaced `timeout`)
- Fix OpenCost duplicate `CONFIG_PATH` entries with custom pricing
- Bump Alloy Operator to 0.5.10, Beyla to 1.16.8, kube-state-metrics to 7.5.1, OpenCost to 2.5.23
- Fix empty deployment notes section

### Validation
- No values.yaml changes needed — current config is fully compatible with 3.8.10
- All new settings (OTLP timeout, Loki WAL) are optional additions
- The OTLP timeout fix is the most impactful change: users with timeout configured on OTLP destinations would see Alloy fail to start on 1.16.3+ with the old chart