### PR TITLE
feat: enable Loki Operational UI plugin in Grafana

### DIFF
--- a/apps/observability/grafana/values.yaml
+++ b/apps/observability/grafana/values.yaml
@@ -59,6 +59,7 @@ testFramework:
 plugins:
   - grafana-strava-datasource
   - grafana-image-renderer
+  - grafana-lokioperational-app
 
 env:
   # https://grafana.com/grafana/plugins/grafana-strava-datasource/

--- a/apps/observability/loki/values.yaml
+++ b/apps/observability/loki/values.yaml
@@ -1,5 +1,7 @@
 ---
 loki:
+  ui:
+    enabled: true
   commonConfig:
     replication_factor: 1
   schemaConfig:


### PR DESCRIPTION
## Changes

Two commits:

1. **`loki/values.yaml`** — Re-adds `loki.ui.enabled: true` (without the `gateway` block). This enables the `-target=ui` flag on Loki pods so they serve the `/ui/api/v1/...` REST endpoints. The Grafana plugin requires these — they are **not** the old bundled SPA, just the API backend.

2. **`grafana/values.yaml`** — Adds `grafana-lokioperational-app` to the plugin list. After sync, the Loki admin console will be accessible within Grafana.

## How to use

After merge and sync, the plugin appears in Grafana under a new "Loki Operational" section. It uses the existing Loki datasource to talk to the `/ui/api/v1/...` endpoints Loki now serves.