### PR TITLE
feat: provision Loki Operational plugin configuration via GitOps

### DIFF
--- a/apps/observability/grafana/sealed-secret.yaml
+++ b/apps/observability/grafana/sealed-secret.yaml
@@ -36,3 +36,21 @@ spec:
       creationTimestamp: null
       name: auth-generic-oauth-secret
     type: Opaque
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: "true"
+  creationTimestamp: null
+  name: loki-operational-plugin-provisioning
+spec:
+  encryptedData:
+    apps.yaml: AgB7WxIsyTomUrMb941c4t30TIDJRuK1O26MRbSG44j+kRn2Y4hMsTb7YWCd1bKDQJHsK3JJwxBQIXO1bICQviojT5ISJB/SHRw/EFPZEfCHYp18IwmTAHupKo24ylwcUnK5vSbWHtx3RulkicqB/+tB06ubvpxhcwr1NNMBHGDEO1EnehKhj5npLLh+ocNHTR8ginIhO3+vNOqFfVJUMK9cwDvcsNeFudwYGewfcYdx1zjOBNiAcEs55ZZNtFHljA+QTXdrvcy1GijuF+35SeD1AO7OIl2IL98iWfGJ2/jS9rxs9gxt8VoEUF2jJvK3IwVr6D1Ckn5ckrFB8+iSGarIj+TYoCSWvAI3b0FZ8YZM3gr5hcUf/X02zsDInywTfirX5X2xtG8bpbsin7OwMkEBq2mved0DqtUnVYwknWO41NWGJ/V1beMbEYpCGmSHbXtB50GnAKHJnHamwTZBDRT7PNIib6iJbH9M91Iap9iJcRLDAmI1UkKgvlrYCuQ5wPOe9q4KBnmgFkdFke7qcMck//fvDdgvcD1V28WSknSao61OGiElKxbXPG6mlB684NvfS/NA4pYYEa4D/HElmKLBOqYC3BBSN8JGOwzB6zkWKkpAWsbGA6UB5RniF/eImpUV9jGACB4xm7AZi0UdFJpt4UPu7ZdVamAiZw3aOtfwqZaPTGe6Rqw/k0KtGFVVkyKOpQRq5e+GgyHfcun+e+rOKIlXOfnM6GieIJ/J1fWc9QWl0i/DAbuDiX2r8+7Rr+DRH00cKAKHzqUbAzhh/FxwOAIJrPsLEJWXum5rtngVDtF5+rIi3m476A7uCREdhZZDD4C8wPsibFgvoBI7ZAmobZiIrdCGUMGREVYOOuQ04H/yEurF2RgCsfauWGVxC9o5+4lh9xBb60kzLYNo063ZD7GO6OnLZvfGq2zkmkgt0WwGHOuMZVop33wfmi4XQ/mampboTk51y0ghkfJAsCwVUOBRgglOPUJBST41HFizgo7yZRLjfg==
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/cluster-wide: "true"
+      creationTimestamp: null
+      name: loki-operational-plugin-provisioning
+

--- a/apps/observability/grafana/values.yaml
+++ b/apps/observability/grafana/values.yaml
@@ -74,5 +74,11 @@ admin:
 imageRenderer:
   enabled: true
 
+extraSecretMounts:
+  - name: loki-operational-plugin-provisioning
+    mountPath: /etc/grafana/provisioning/plugins
+    secretName: loki-operational-plugin-provisioning
+    readOnly: true
+
 nodeSelector:
   kubernetes.io/hostname: n200


### PR DESCRIPTION
## Changes

Provisions the `grafana-lokioperational-app` plugin configuration so it connects to Loki's admin APIs without needing manual setup.

### How it works

Grafana reads app plugin configurations from YAML files under `/etc/grafana/provisioning/plugins/`. A SealedSecret holds the provisioning YAML and is mounted via `extraSecretMounts`.

| File | Purpose |
|------|---------|
| `loki-operational-plugin-provisioning.yaml` | SealedSecret with `apps.yaml` key containing the plugin config |
| `values.yaml` | `extraSecretMounts` entry mounting the secret at the provisioning path |
| `kustomization.yaml` | Adds the SealedSecret as a resource |

### Plugin config

```yaml
apiUrl: http://loki.observability.svc.cluster.local:3100  # internal cluster URL
apiKey: ""  # Loki has auth_enabled: false, no key needed
```

After merge and sync, the plugin appears in Grafana under a "Loki Operational" section, pre-configured to talk to Loki.