### PR TITLE
chore: update infrastructure and observability Helm charts

### DIFF
--- a/apps/backup/kustomization.yaml
+++ b/apps/backup/kustomization.yaml
@@ -8,10 +8,10 @@ helmCharts:
   - name: k8up
     repo: https://k8up-io.github.io/k8up
     namespace: backup
-    version: 4.8.6
+    version: 4.9.0
     releaseName: k8up
     valuesFile: values.yaml
 
 resources:
   - sealed-secret.yaml
-  - https://github.com/k8up-io/k8up/releases/download/k8up-4.8.6/k8up-crd.yaml
+  - https://github.com/k8up-io/k8up/releases/download/k8up-4.9.0/k8up-crd.yaml

--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.21.0/cert-manager.yaml
   - cluster-issuer.yaml
   - sealed-secret.yaml
   - certificate.yaml
@@ -12,6 +12,7 @@ helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
     namespace: cert-manager
+    version: 10.0.58
     releaseName: reflector
 
 #patches:

--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/cloudnativepg/kustomization.yaml
+++ b/apps/cloudnativepg/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
-    version: 0.27.1
+    version: 0.29.0
     namespace: cnpg
     releaseName: cloudnative-pg
     valuesFile: values.yaml

--- a/apps/descheduler/kustomization.yaml
+++ b/apps/descheduler/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.35
+  - github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.36
 
 patches:
   - path: cronjob-patch.yaml

--- a/apps/ingress-nginx/kustomization.yaml
+++ b/apps/ingress-nginx/kustomization.yaml
@@ -6,6 +6,6 @@ helmCharts:
   - name: ingress-nginx
     repo: https://kubernetes.github.io/ingress-nginx
     namespace: ingress-nginx
-    version: 4.13.1
+    version: 4.15.1
     releaseName: ingress-nginx
     valuesFile: values.yaml

--- a/apps/k8s-gateway/kustomization.yaml
+++ b/apps/k8s-gateway/kustomization.yaml
@@ -8,6 +8,6 @@ helmCharts:
   - name: k8s-gateway
     repo: https://k8s-gateway.github.io/k8s_gateway/
     namespace: kube-system
-    version: 3.2.7
+    version: 3.7.2
     releaseName: excoredns
     valuesFile: values.yaml

--- a/apps/observability/grafana-operator/kustomization.yaml
+++ b/apps/observability/grafana-operator/kustomization.yaml
@@ -9,11 +9,11 @@ helmCharts:
   - name: grafana-operator
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 5.21.4
+    version: 5.24.0
     releaseName: grafana-operator
     valuesFile: values.yaml
 
 resources:
-  - https://github.com/grafana/grafana-operator/releases/download/v5.21.4/crds.yaml
+  - https://github.com/grafana/grafana-operator/releases/download/v5.24.0/crds.yaml
   - grafana.yaml
   - sealed-secret.yaml

--- a/apps/observability/grafana/kustomization.yaml
+++ b/apps/observability/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: grafana
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 12.1.1
+    version: 12.7.2
     releaseName: grafana
     valuesFile: values.yaml
 

--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.10
+    version: 4.2.1
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/opentelemetry-operator/kustomization.yaml
+++ b/apps/observability/opentelemetry-operator/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: opentelemetry-operator
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts
     namespace: observability
-    version: 0.110.0
+    version: 0.119.0
     releaseName: opentelemetry-operator
     valuesFile: values.yaml
 

--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 78.1.0
+    version: 87.15.1
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml

--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.15.1
+    version: 2.1.0
     releaseName: pyroscope
     valuesFile: values.yaml
 

--- a/apps/observability/tempo/kustomization.yaml
+++ b/apps/observability/tempo/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: tempo
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.23.3
+    version: 1.24.4
     releaseName: tempo
     valuesFile: values.yaml
 

--- a/apps/sealed-secrets/kustomization.yaml
+++ b/apps/sealed-secrets/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 namespace: sealed-secrets
 resources:
-  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.31.0/controller.yaml
+  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.38.4/controller.yaml
 
 patches:
   - target:

--- a/apps/tailscale/kustomization.yaml
+++ b/apps/tailscale/kustomization.yaml
@@ -12,6 +12,6 @@ helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
     namespace: tailscale
-    version: 1.88.2
+    version: 1.98.4
     releaseName: tailscale-operator
     valuesFile: values.yaml


### PR DESCRIPTION
## Changes

Updates **16 files** across infrastructure and observability components to their latest available versions.

### Infrastructure Charts
| Chart | Current | → | Latest | Source |
|---|---|---|---|---|
| cilium | 1.18.2 | → | 1.19.5 | [helm.cilium.io](https://helm.cilium.io/) |
| cloudnative-pg | 0.27.1 | → | 0.29.0 | [cloudnative-pg.github.io/charts](https://cloudnative-pg.github.io/charts) |
| tailscale-operator | 1.88.2 | → | 1.98.4 | [pkgs.tailscale.com/helmcharts](https://pkgs.tailscale.com/helmcharts) |
| ingress-nginx | 4.13.1 | → | 4.15.1 | [kubernetes.github.io/ingress-nginx](https://kubernetes.github.io/ingress-nginx) |
| k8s-gateway | 3.2.7 | → | 3.7.2 | [k8s-gateway.github.io/k8s_gateway](https://k8s-gateway.github.io/k8s_gateway/) |
| reflector | *(unpinned)* | → | 10.0.58 | [emberstack.github.io/helm-charts](https://emberstack.github.io/helm-charts) |
| k8up | 4.8.6 | → | 4.9.0 | [k8up-io.github.io/k8up](https://k8up-io.github.io/k8up) |
| cert-manager | v1.18.2 | → | v1.21.0 | [releases](https://github.com/cert-manager/cert-manager/releases) |
| sealed-secrets | v0.31.0 | → | v0.38.4 | [releases](https://github.com/bitnami-labs/sealed-secrets/releases) |
| descheduler | release-1.35 | → | release-1.36 | [branches](https://github.com/kubernetes-sigs/descheduler) |

### Observability Charts
| Chart | Current | → | Latest | Source |
|---|---|---|---|---|
| kube-prometheus-stack | 78.1.0 | → | 87.15.1 | [prometheus-community.github.io/helm-charts](https://prometheus-community.github.io/helm-charts) |
| grafana | 12.1.1 | → | 12.7.2 | [grafana-community.github.io/helm-charts](https://grafana-community.github.io/helm-charts) |
| grafana-operator | 5.21.4 | → | 5.24.0 | [grafana.github.io/helm-charts](https://grafana.github.io/helm-charts) |
| k8s-monitoring | 3.8.10 | → | 4.2.1 | [grafana.github.io/helm-charts](https://grafana.github.io/helm-charts) |
| pyroscope | 1.15.1 | → | 2.1.0 | [grafana.github.io/helm-charts](https://grafana.github.io/helm-charts) |
| tempo | 1.23.3 | → | 1.24.4 | [grafana.github.io/helm-charts](https://grafana.github.io/helm-charts) |
| opentelemetry-operator | 0.110.0 | → | 0.119.0 | [open-telemetry.github.io](https://open-telemetry.github.io/opentelemetry-helm-charts) |

### Notes

- ⚠️ Some bumps are **major** (kube-prometheus-stack: 78→87, pyroscope: 1→2, k8s-monitoring: 3→4). These may introduce breaking changes — review the chart changelogs before merging.
- **loki** (18.4.4) already at latest — no change.
- **16  images** (homepage, freshrss, linkding, thelounge, wallabag, jellyfin, radarr, sonarr, prowlarr, qbittorrent, it-tools, busybox) are inherently up-to-date and left unchanged.
- Application chart bumps (authentik, immich) and pinned image tag updates are in a separate PR.