### PR TITLE
chore: update application charts and container image tags

### DIFF
--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   - name: authentik
     repo: https://charts.goauthentik.io
     namespace: authentik
-    version: 2026.2.2
+    version: 2026.5.4
     releaseName: authentik
     valuesFile: values.yaml
 

--- a/apps/freshrss/pre-backup-pod.yaml
+++ b/apps/freshrss/pre-backup-pod.yaml
@@ -11,7 +11,7 @@ spec:
         runAsUser: 0
       containers:
         - name: freshrss-sqlite-dump
-          image: alpine/sqlite:3.51.2
+          image: alpine/sqlite:3.53.2
           command:
             - 'sleep'
             - 'infinity'

--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: immich
     repo: https://immich-app.github.io/immich-charts
     namespace: immich
-    version: 0.10.3
+    version: 0.12.0
     releaseName: immich
     valuesFile: values.yaml
 

--- a/apps/media/qbittorrent/metrics-exporter.yaml
+++ b/apps/media/qbittorrent/metrics-exporter.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: prometheus-qbittorrent-exporter
-          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:1.7.0
           env:
             - name: QBITTORRENT_PORT
               value: "80"

--- a/apps/observability/grafana/pre-backup-pod.yaml
+++ b/apps/observability/grafana/pre-backup-pod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: grafana-sqlite-dump
-          image: alpine/sqlite:3.51.2
+          image: alpine/sqlite:3.53.2
           command:
             - 'sleep'
             - 'infinity'


### PR DESCRIPTION
## Changes

Updates **7 files** — two Helm chart bumps and five container image tag updates.

### Application Charts
| Chart | Current | → | Latest | Source |
|---|---|---|---|---|
| authentik | 2026.2.2 | → | 2026.5.4 | [charts.goauthentik.io](https://charts.goauthentik.io) |
| immich | 0.10.3 | → | 0.12.0 | [immich-app.github.io](https://immich-app.github.io/immich-charts) |

### Container Images
| Image | Current | → | Latest | Source |
|---|---|---|---|---|
| amazon/aws-cli | 2.31.31 | → | 2.35.21 | [Docker Hub](https://hub.docker.com/r/amazon/aws-cli) |
| alpine/sqlite (freshrss pre-backup) | 3.51.2 | → | 3.53.2 | [Docker Hub](https://hub.docker.com/r/alpine/sqlite) |
| alpine/sqlite (grafana pre-backup) | 3.51.2 | → | 3.53.2 | [Docker Hub](https://hub.docker.com/r/alpine/sqlite) |
| prometheus-qbittorrent-exporter | *(untagged)* | → | 1.7.0 | [releases](https://github.com/esanchezm/prometheus-qbittorrent-exporter/releases) |
| cloudflare/cloudflared | latest | → | 2026.7.1 | [releases](https://github.com/cloudflare/cloudflared/releases) |

### Notes
- The qbittorrent-exporter and cloudflared images were previously using `:latest` — pinned to the current release tag for reproducibility.
- shelly-exporter (v0.4.3) and itarmykit-headless (2.2.8) already at their latest available versions.
- Infrastructure + observability chart bumps are in PR #275.