### PR TITLE
chore(deps): cloudnative-pg 0.27.1 → 0.29.0

### DIFF
--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/cloudnativepg/kustomization.yaml
+++ b/apps/cloudnativepg/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
-    version: 0.27.1
+    version: 0.29.0
     namespace: cnpg
     releaseName: cloudnative-pg
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cloudnative-pg | 0.27.1 | → | 0.29.0 | 🟡 |

## Breaking Changes / Upgrade Notes

- **Cluster reference immutability**: The `cluster` field is now immutable on `Database`, `Pooler`, `Publication`, `Subscription`, and `ScheduledBackup` resources. Updates attempting to re-point these objects to a different cluster are now rejected via a CEL validation rule.
- **Operator-side SCRAM-SHA-256 password encoding** (CVE-2026-55765): The operator now encodes cleartext passwords before sending them to PostgreSQL. If you have explicitly overridden `password_encryption` to a non-default value, set `cnpg.io/passwordPassthrough: "enabled"` on the basic-auth Secret.
- **search_path pinning** (CVE-2026-55769): The operator now pins `search_path = pg_catalog, public, pg_temp` on operator-issued connections.
- **Authenticated instance communication** (GHSA-7qwx-x8ff-3px9): Operator-to-instance-manager calls now require ECDSA certificate authentication.
- Standard rolling update of all PostgreSQL clusters will follow the operator upgrade, with an automatic switchover (unsupervised).

## Changelog (operator 1.28.x → 1.30.0)

### Features
- **DatabaseRole CRD**: Declarative PostgreSQL role management as standalone Kubernetes objects (GitOps-friendly)
- **Primary Lease**: Kubernetes Lease-based mutex for safe primary election (`.spec.primaryLease`)
- **PgBouncer image catalogs**: Pooler can reference ImageCatalog/ClusterImageCatalog entries
- **TLS for Pooler metrics**: HTTPS metrics endpoint via `.spec.monitoring.tls.enabled`
- **VPA/HPA support**: Cluster becomes a valid targetRef via `status.selector`
- **In-place pg_upgrade with Image Volume extensions**: PostgreSQL 19+ support
- Kubernetes 1.36 support, default PostgreSQL updated to 18.4

### Security
- CVE-2026-55769 (search_path pinning)
- CVE-2026-55765 (SCRAM-SHA-256 password encoding)
- GHSA-7qwx-x8ff-3px9 (authenticated operator-to-instance-manager calls)

### Notable Fixes
- Fixed backup stuck in `pending` forever
- Fixed switchover deadlock with WAL-archiver plugins
- Fixed race conditions in bootstrap recovery
- Fixed concurrent backup resource leaks
- Fixed atomic certificate file writes
- Many more bug fixes (see full release notes)

## Source

https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.30.0