### PR TITLE
chore(deps): tailscale-operator 1.88.2 → 1.98.4

### DIFF
--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/cloudnativepg/kustomization.yaml
+++ b/apps/cloudnativepg/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
-    version: 0.27.1
+    version: 0.29.0
     namespace: cnpg
     releaseName: cloudnative-pg
     valuesFile: values.yaml

--- a/apps/tailscale/kustomization.yaml
+++ b/apps/tailscale/kustomization.yaml
@@ -12,6 +12,6 @@ helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
     namespace: tailscale
-    version: 1.88.2
+    version: 1.98.4
     releaseName: tailscale-operator
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| tailscale-operator | 1.88.2 | → | 1.98.4 | 🟡 |

## Breaking Changes / Upgrade Notes

- **`TS_EXPERIMENTAL_KUBE_API_EVENTS` env var removed** (around 1.96.x): This environment variable is no longer recognized. API request event recording should be configured via [Tailscale ACLs](https://tailscale.com/docs/kubernetes-operator/how-to/session-recording#enabling-api-request-event-recording) instead.
- **Multi-tailnet support**: The new `Tailnet` custom resource enables multi-tailnet access. If you had any custom automation around tailnet switching, review the new CRD.
- **ProxyGroupPolicy CRD**: ProxyGroup creation controls can now be managed by namespace. Existing ProxyGroups should continue working without changes.
- **Workload identity federation**: The operator now supports authentication using provider-native identity tokens (1.94+). If you use OAuth client secrets, no change is needed.
- **Certificate renewal**: No longer done as an ARI order by default (avoids renewal failures if ACME account keys are recreated).
- **Hardware attestation keys**: No longer added to Kubernetes state Secrets, making it possible to change the Kubernetes node the operator is deployed on.
- **Helm chart**: Now supports `priorityClassName` for operator pods (new values field — optional, no breaking change).
- **DNSConfig CRD**: Now supports `nodeAffinity` and `nodeSelector` for nameserver pods (new fields — optional, backward compatible).

## Changelog

### v1.98.4 (May 28, 2026)
- Fixed: Operator no longer fails to perform token exchanges when using workload identity
- Fixed: Ingress & Egress ProxyGroup pods now correctly clamp their MTU values

### v1.98.3 (May 22, 2026)
- New: DNSConfig custom resource supports specifying node affinity rules and node selectors for nameserver pods
- New: Helm chart supports priority class names for operator pods
- Fixed: Operator now reconciles Services and Ingresses with names longer than 63 characters
- Fixed: ProxyGroup egress services now obtain an IPv4 address in addition to IPv6 on dual-stack clusters
- Fixed: API server proxy ProxyGroup pods request a new auth key when required

### v1.96.x
- Ingress and Egress ProxyGroup pods can request a new authkey when required
- New `Tailnet` custom resource for multi-tailnet access
- New `ProxyGroupPolicy` custom resource for namespace-scoped ProxyGroup controls
- `TS_EXPERIMENTAL_KUBE_API_EVENTS` removed — use Tailscale ACLs instead

### v1.94.x
- Egress proxy can send traffic to Tailscale service VIPs
- Kubernetes API server proxy audit logging (beta)
- HA mode: write replica no longer serves stale TLS certificates after renewal
- Workload identity federation support
- `tailscale.com/http-redirect` annotation for Ingress HTTP→HTTPS redirects
- Recorder resources can specify replica count for HA deployments
- Invalid Tailscale FQDN for egress no longer crashes — logs error instead

### v1.90.x / v1.92.x (intermediate)
- Workload identity federation and OAuth support for containers
- Certificate renewal no longer uses ARI order by default
- Hardware attestation keys removed from Kubernetes state Secrets
- Helm templating fix for OAuth client secret edge case
- `iptables` fallback support on hosts without `nftables`

## Source

https://github.com/tailscale/tailscale/releases/tag/v1.98.4
