### PR TITLE
chore(deps): sealed-secrets v0.31.0 → v0.38.4

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/sealed-secrets/kustomization.yaml
+++ b/apps/sealed-secrets/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 namespace: sealed-secrets
 resources:
-  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.31.0/controller.yaml
+  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.38.4/controller.yaml
 
 patches:
   - target:

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| sealed-secrets | v0.31.0 | → | v0.38.4 | 🟢 |

## Breaking Changes / Upgrade Notes

No breaking CRD or API changes detected between v0.31.0 and v0.38.4. Notable changes to be aware of:

- **v0.36.0**: Security fix — controller now throws errors on inconsistencies in SealedSecret resources and preserves scope during key rotation.
- **v0.38.0**: Security context defaults updated to comply with the Kubernetes restricted pod security standard profile. The controller now ships with more restrictive security defaults.
- **v0.38.0**: Org migration from `bitnami-labs` to `bitnami` (controller.yaml URL still uses the old path for releases, so no change needed in the kustomization URL structure).
- **v0.37.0**: `template.data` values now exposed in template rendering context.
- No CRD schema changes — existing SealedSecrets (including those created under v0.31.0) will continue to work without re-encryption.

## Changelog

### v0.38.4
- Incomplete release for credentials problems

### v0.38.3
- Incomplete release for credentials problems

### v0.38.2
- Publish Artifact Hub repository metadata for verified publisher status
- Add Artifact Hub badge to README
- Various dependency bumps (k8s.io/api, k8s.io/client-go, ginkgo, gomega)

### v0.38.1
- Incomplete release for credentials problems

### v0.38.0
- feat: add ppc64le architecture support
- Add default prometheusRule in helmChart to watch out of sync secrets
- Update security context defaults to comply with restricted pod security standard profile
- fix: add mutex locking to KeyRegistry to prevent data races
- Bump Golang to 1.26.4
- Migrate all bitnami-labs references to bitnami org
- Change OCI registry for publishing the chart

### v0.37.0
- Expose plaintext template.data values in template rendering context
- Bump Go version to 1.26.3
- Bump k8s.io/api, client-go, apimachinery and code-generator to 0.36.1
- Various dependency bumps

### v0.36.0 — v0.36.6
- [Security] Preserve scope during Sealed Secret rotation
- [Security] Throw an error in case of inconsistencies in the Sealed Secrets
- Bump Golang to 1.26.2
- fix: send INFO logs to stdout by default
- Various dependency bumps

### v0.35.0
- "my namespace as key namespace" feature
- Bump Go to 1.25.7
- Update client-go and api to 0.35.0

### v0.34.0
- Add kseal to README
- Bump golang to 1.24
- Make controllers kubeclient QPS & Burst configurable
- Use default method to watch for key secrets

### v0.33.0 — v0.33.1
- Bump Go to 1.25.4
- Fix missing helm chart code

### v0.32.0 — v0.32.2
- Fix regression mismatching namespace
- K8s API bumps to 0.34.0

## Source

https://github.com/bitnami-labs/sealed-secrets/releases/tag/v0.38.4