### PR TITLE
chore(deps): reflector unpinned → 10.0.58

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -12,6 +12,7 @@ helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
     namespace: cert-manager
+    version: 10.0.58
     releaseName: reflector
 
 #patches:

--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/tailscale/kustomization.yaml
+++ b/apps/tailscale/kustomization.yaml
@@ -12,6 +12,6 @@ helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
     namespace: tailscale
-    version: 1.88.2
+    version: 1.98.4
     releaseName: tailscale-operator
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| reflector | *(unpinned)* | → | 10.0.58 | 🟢 |

## Breaking Changes / Upgrade Notes

This pins the reflector chart to a specific version (previously unpinned, using whatever the repo latest was at sync time).

## Changelog

- Bump the all-dependencies group with 6 updates (#682)

## Source

https://github.com/emberstack/helm-charts/releases