### PR TITLE
chore(deps): cilium 1.18.2 → 1.19.5

### DIFF
--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/tailscale/kustomization.yaml
+++ b/apps/tailscale/kustomization.yaml
@@ -12,6 +12,6 @@ helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
     namespace: tailscale
-    version: 1.88.2
+    version: 1.98.4
     releaseName: tailscale-operator
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cilium | 1.18.2 | → | 1.19.5 | 🟡 |

## Breaking Changes / Upgrade Notes

See https://docs.cilium.io/en/v1.19/operations/upgrade/ for full details.

### Action Required

**Network Policy:**
- DNS patterns with `**` now match multiple subdomains (previously treated same as `*`). Check patterns starting with `**.`.
- `FromRequires` and `ToRequires` fields now enforced empty — policies using these must be updated before upgrade.
- Kafka Network Policy support is deprecated (will be removed in 1.20).
- `mesh-auth-enabled` (Helm `authentication.enabled`) is now **disabled by default** — enable explicitly if using Mutual Authentication.

**Cluster Mesh:**
- `policy-default-local-cluster` defaults to `true` — network policy selectors only select endpoints from the local cluster by default. Set to `false` to retain previous behavior, or update policies with explicit cluster selectors.
- `clustermesh.apiserver.tls.authMode` defaults to `migration` — create `clustermesh-remote-users` ConfigMap or set `authMode=legacy` if using specific configurations.

**Custom Resource Versions:**
- `CiliumLoadBalancerIPPool`: change `apiVersion: cilium.io/v2alpha1` → `cilium.io/v2`
- `CiliumBGPPeeringPolicy` (BGPv1) CRD **removed** — migrate to `cilium.io/v2` CRDs (`CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`, `CiliumBGPNodeConfigOverride`) before upgrading.

**Removed Flags:**
- `--enable-node-port`, `--enable-host-port`, `--enable-external-ips` removed (use `--kube-proxy-replacement=true`)
- `--enable-ipv4-egress-gateway` removed (use `--enable-egress-gateway=true`)
- `--l2-pod-announcements-interface` removed (use `--l2-pod-announcements-interface-pattern`)
- PCAP recorder, session-affinity, internal-traffic-policy, svc-source-range-check flags removed
- `--enable-custom-calls`, `--bpf-lb-proto-diff` removed
- `--egress-multi-home-ip-rule-compat` removed

### Informational

- BPF Host-Routing with IPsec now requires a kernel bugfix (CVE-2025-37959). Ensure kernel is up to date, or set `--enable-host-legacy-routing=true`.
- `bpf.tproxy=true` is incompatible with netkit datapath mode. Use veth or disable `bpf.tproxy`.
- Hubble field mask API stabilized: `--experimental-field-mask` → `--field-mask` (enabled by default).
- `--unmanaged-pod-watcher-interval` flag type changed from `int` (seconds) to `time.Duration` (e.g., `15` → `15s`).
- Certificate generation with CronJob method changed — Job resources no longer use Helm post-install hooks.
- MCS-API CRDs are now installed and managed by Cilium by default (opt out with `clustermesh.mcsapi.installCRDs=false`).

## Changelog

### Releases between 1.18.2 and 1.19.5

**1.18.x patch releases**: 1.18.3, 1.18.4, 1.18.5, 1.18.6, 1.18.7, 1.18.8, 1.18.9, 1.18.10, 1.18.11

**1.19.x releases**: 1.19.0, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.19.5

### 1.19.5 (Jun 16, 2026) — Latest patch

**Minor Changes:**
- Extend the information reported by the troubleshoot kvstore and clustermesh commands
- helm: Remove loadBalancer.standalone option
- wireguard:mtu: fix mtu calculation with potential padding

**Bugfixes:**
- Fix CiliumNetworkPolicy with `fromNodes`/`toNodes` and `policy-default-local-cluster` enabled (always add cluster label to node when `nodeSelectorLabels` is enabled)
- azure: Fix public IP reassignment failure loop on operator restart
- bgp: Dont provide default_gateway reconciler when disabled; reduce amount of soft peer resets by service reconciliation
- bpf: fix host proxy packet routing to pods
- Fix weighted backend traffic splitting for TLSRoute passthrough listeners in Gateway API
- Fix NamespaceSelector corruption in CiliumEgressGatewayPolicy
- Fix clustermesh-apiserver endpoint deletion under high pod churn
- Fix BGP PeerConfig status cleanup timeout
- Fix connectivity disruption when ClusterIP/LoadBalancer VIPs overlap with node-local IPs
- Fix TLS passthrough routes failing silently with mixed Gateway listeners
- Fix wildcard namespace bypass for selectorless ipBlock rules
- Fix Gateway API controller panic on malformed GatewayClass/parametersRef
- Fix EndpointSlice ready condition in gateway-api
- Fix policymap pressure incorrectly reported as 0
- Fix unsolicited IPv6 L2 announcements (RFC 4861 compliance)
- Fix reused endpoint ID BPF state directory race
- Fix nil pointer dereference panic (uninitialized logger)
- Various Gateway API, Hubble, and IPAM fixes
- iptables: match wireguard packets by proto+port instead of packet mark
- Internal representation of load-balancing backends refactored for scale (thousands of services sharing a backend)

## Source

https://github.com/cilium/cilium/releases/tag/v1.19.5

## Upgrade Reference

https://docs.cilium.io/en/stable/operations/upgrade/