### PR TITLE
chore(deps): ingress-nginx 4.13.1 → 4.15.1

### DIFF
--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/cloudnativepg/kustomization.yaml
+++ b/apps/cloudnativepg/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
-    version: 0.27.1
+    version: 0.29.0
     namespace: cnpg
     releaseName: cloudnative-pg
     valuesFile: values.yaml

--- a/apps/ingress-nginx/kustomization.yaml
+++ b/apps/ingress-nginx/kustomization.yaml
@@ -6,6 +6,6 @@ helmCharts:
   - name: ingress-nginx
     repo: https://kubernetes.github.io/ingress-nginx
     namespace: ingress-nginx
-    version: 4.13.1
+    version: 4.15.1
     releaseName: ingress-nginx
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| ingress-nginx | 4.13.1 | → | 4.15.1 | 🟡 |

## Breaking Changes / Upgrade Notes

- **Project Retirement**: ingress-nginx was archived on Mar 24, 2026. This is the final release line. Plan migration to an alternative ingress controller (e.g., nginxinc ingress or gateway-api).
- **Template quoting changes**: `proxy_pass`, `location`, and `server_name` directives are now properly quoted. Custom configurations relying on unquoted template overrides may need updates.
- **SSL Proxy**: PROXY protocol v2 support added for SSL passthrough.
- **Auth method regex**: Stricter validation — `^` and `$` anchors added to auth method regex; custom auth methods may be affected.
- **Stronger ciphers default**: Config now uses stronger ciphers first by default.
- **Helm v4.x**: CI updated from Helm v3 to v4 (chart templating should be backward compatible).
- **Alpine bumped** to v3.23.3, **Go bumped** to v1.26.1.

## Changelog

### helm-chart-4.15.1 (controller-v1.15.1)
- Update Ingress-Nginx version controller-v1.15.1
- Template: Remove path from comment
- CI: Update Kubernetes to v1.35.3
- CI: Update Helm to v4.1.3
- Go: Update dependencies
- Various dependency bumps

### helm-chart-4.15.0 (controller-v1.15.0)
- Update Ingress-Nginx version controller-v1.15.0
- Template: Quote `proxy_pass`, `location`, and `server_name` directives
- Annotations: Consider aliases in risk evaluation
- Annotations: Use dedicated regex for `proxy-cookie-domain`
- Annotations: Add `^` and `$` to auth method regex
- Controller: Enable SSL Passthrough when requested on before HTTP-only hosts
- Controller: Use 4KiB buffers for PROXY protocol parsing in TLS passthrough
- Controller: Fix sync for host clock jumps to future
- Controller: Verify UIDs
- Admission Controller: Remove obsolete error log, Use 9 MB limit
- Template: Bypass custom error pages when handling auth URL requests
- Template: Use `RawURLEncoding` instead of `URLEncoding` with padding removal
- Config: Use stronger ciphers first
- Lua: Fix type mismatch
- Util: Fix panic for empty `cpu.max` file
- Go: Bump to v1.26.1
- CI: Update Kubernetes to v1.35.2, KIND to v1.35.1
- CI: Update Helm to v4.1.1
- Images: Bump Alpine to v3.23.3
- Images: Bump NGINX to v2.2.8
- Tests: Bump Ginkgo to v2.28.1, Test Runner to v2.2.8
- Docs: Add retirement notice
- Various dependency bumps

### helm-chart-4.14.x series (controller-v1.14.x)
The 4.14.x series introduced controller-v1.14.0 which included:
- SSL Proxy: PROXY protocol v2 support
- Status: Multiple Node IP addresses support
- Chart: Make extra init containers templatable, add resize policy, add scrapeTimeout
- Controller: Fix `limit_req_zone` sorting
- Store: Handle panics in service deletion handler
- Go: Bump to v1.25.x
- CI: Update Kubernetes to v1.34.x, Helm to v3.19.x
- Chart: Bump Kube Webhook CertGen
- Various dependency bumps and fixes

### helm-chart-4.13.x series (controller-v1.13.x)
The 4.13.x releases after 4.13.1 consisted of patch updates and dependency bumps within the v1.13 controller line, culminating in controller-v1.13.9.

## Source

https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.15.1