### PR TITLE
chore(deps): cert-manager v1.18.2 → v1.21.0

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.21.0/cert-manager.yaml
   - cluster-issuer.yaml
   - sealed-secret.yaml
   - certificate.yaml

--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.18.2
+    version: 1.19.5
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml

--- a/apps/cloudnativepg/kustomization.yaml
+++ b/apps/cloudnativepg/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
-    version: 0.27.1
+    version: 0.29.0
     namespace: cnpg
     releaseName: cloudnative-pg
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cert-manager | v1.18.2 | → | v1.21.0 | 🟡 |

## Breaking Changes / Upgrade Notes

This is a **two-minor-version jump** (v1.18.2 → v1.21.0). The intermediate releases v1.19.0 and v1.20.0 are included. Below are the key breaking changes introduced across these versions.

### cert-manager v1.21.0 — 3 Breaking Changes

1. **Default `tokenrequest` RBAC removed from Helm chart** — The Helm chart no longer creates a default Role/RoleBinding granting `serviceaccounts/token: create`. If using `serviceAccountRef.name` pointing at the controller SA, create a dedicated ServiceAccount or add the RBAC manually. *(Static manifest users: not directly affected.)*

2. **Restrict Challenge and Order RBAC in `cert-manager-edit` ClusterRole** — The `cert-manager-edit` aggregate ClusterRole no longer grants `create` for `challenges.acme.cert-manager.io` or `create`/`patch`/`update` for `orders.acme.cert-manager.io` (GHSA-8rvj-mm4h-c258). *(Already shipped in v1.20.3; if you have tooling creating these resources directly, grant permissions explicitly.)*

3. **Metrics port name and path Helm values removed** — `prometheus.servicemonitor.targetPort`, `prometheus.servicemonitor.path`, and `prometheus.podmonitor.path` removed. Remove these keys from Helm values before upgrade. *(Static manifest users: not directly affected.)*

### v1.20.0 Highlights
- Gateway API ListenerSet alpha support (XListenerSets feature gate)
- Azure Private DNS support for DNS01
- OtherNames promoted to Beta
- `parentRef` override annotations on Certificate resource
- Vault issuer includes Vault server address in default audiences on SA tokens

### v1.19.0 Highlights
- `CAInjectorMerging` promoted to BETA (enabled by default)
- DNS-over-HTTPS improvements
- Configurable resource requests/limits for ACME HTTP01 solver pods via Issuer/ClusterIssuer
- IPv6 rules in default network policy
- Global nodeSelector via Helm chart
- Version and git commit logged on startup

## Changelog

### v1.21.0 (Jul 8, 2026)
- **ACME Renewal Information (ARI)** — experimental support for RFC 9773 behind `ACMEUseARI` feature gate
- **AWS IAM authentication for Vault issuer** — IRSA, EKS Pod Identity, ambient EC2/ECS credentials
- **`waitInsteadOfSelfCheck`** — skip self-check and wait configured duration before ACME validation
- **Certificate renewal policies** — new `renewalPolicies` field on Certificate API
- **Configurable CertificateRequest retry backoff** — `--certificate-request-maximum-backoff-duration` flag (default: 32h)
- **Modern2026 PKCS#12 profile** — FIPS 140-3 compatible (AES-256 + SHA-256 KDFs)
- **Webhook certificate renewal after system suspend** — recovers within 1 minute of resume
- **Gateway API improvements** — HTTP01 ListenerSet parentRef fallback, `ignore-tls-listeners` annotation, additional listener protocols, `enableGatewayAPI` config restructured to `gatewayAPI.enabled`
- **`CAInjectorMerging` promoted to GA** — unconditionally enabled
- **cainjector SSA unconditional** — `ServerSideApply` feature gate deprecated
- **cainjector `--ignore-namespaces` flag** — filter namespaces from injection watches
- **Venafi OAuth observability** — new `AuthFailed` Issuer condition reason
- **`runtimeClassName` support** — configurable for cert-manager components and HTTP01 solver pods
- **`startupapicheck.ttlSecondsAfterFinished`** — opt-in automatic Job cleanup
- **`--acme-http01-solver-extra-labels`** — propagate `global.commonLabels` to ACME HTTP01 solver resources

### v1.19.0 (Oct 7, 2025)
- IPv6 rules in default network policy (PR #7726)
- `global.nodeSelector` Helm chart support (PR #7818)
- Ingress `pathType=Exact` feature gate for ACME HTTP01 (PR #7795)
- Generated `applyconfigurations` for type-safe SSA (PR #7866)
- `certmanager_certificate_challenge_status` Prometheus metric (PR #7736)
- `protocol` field for RFC2136 DNS01 provider (PR #7881)
- Configurable ACME HTTP01 solver resource requests/limits via Issuer (PR #7972)
- `CAInjectorMerging` BETA (enabled by default) (PR #8017)
- Version logging on startup (PR #8072)

### v1.20.0 (Mar 10, 2026)
- Selectable fields on CRDs for `.spec.issuerRef.{group,kind,name}` (PR #8256)
- `imagePullSecrets` for startupapicheck-job (PR #8186)
- Extra sidecar containers via `extraContainers` Helm value (PR #8355)
- `parentRef` override annotations on Certificate (PR #8518)
- Azure Private DNS for DNS01 issuer (PR #8494)
- PEM decoding size limits (PR #7642)
- Venafi custom-fields annotation support (PR #8301)
- `http01-ingress-ingressclassname` annotation (PR #8244)
- Vault SA token audience includes server address (PR #8228)
- Experimental `XListenerSets` feature gate (PR #8394)

## Source

https://github.com/cert-manager/cert-manager/releases/tag/v1.21.0