### PR TITLE
chore(deps): cloudnative-pg 0.27.1 → 0.29.0

### DIFF
--- a/apps/cloudnativepg/kustomization.yaml
+++ b/apps/cloudnativepg/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cloudnative-pg
     repo: https://cloudnative-pg.github.io/charts
-    version: 0.27.1
+    version: 0.29.0
     namespace: cnpg
     releaseName: cloudnative-pg
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cloudnative-pg | `0.27.1` (chart) / `1.27.x` (operator) | → | `0.29.0` (chart) / `1.30.0` (operator) | 🟡 |

## What changed

Single-file bump: `apps/cloudnativepg/kustomization.yaml` — chart version `0.27.1` → `0.29.0`. CRDs are included automatically (`includeCRDs: true`).

## Affected clusters

| Cluster | Namespace | Image | Notes |
|---|---|---|---|
| `immich-database` | immich | `tensorchord/cloudnative-vectorchord:16.9-0.4.3` | Has vchord + earthdistance extensions |
| `authentik-database` | authentik | `cloudnative-pg/postgresql:17.9` | Bootstrap with `initdb`, custom owner secret |
| `maistokainos-database` | maistokainos | `cloudnative-pg/postgresql:17.9` | Custom resource limits, pod affinity, PG parameters |

No cluster uses `password_encryption`, `primaryLease`, `imageCatalog`, or `cnpg.io/passwordPassthrough`.

## Breaking Changes — impact assessment

### 1. Cluster reference immutability (CEL validation)
**Operator 1.28+** — `cluster` field is now immutable on `Database`, `Pooler`, `Publication`, `Subscription`, and `ScheduledBackup` resources.
**Impact: ✅ None** — no such resources exist in any namespace.

### 2. SCRAM-SHA-256 password encoding (CVE-2026-55765)
**Operator 1.29+** — The operator now encodes cleartext passwords (SCRAM-SHA-256) before sending them to PostgreSQL, instead of relying on the server-side `password_encryption` setting.
**Impact: ✅ None** — no cluster sets a non-default `password_encryption` parameter. No action needed.

### 3. search_path pinning (CVE-2026-55769)
**Operator 1.29+** — Operator-issued connections now pin `search_path = pg_catalog, public, pg_temp`.
**Impact: ✅ Low** — transparent to applications. Only affects operator-internal connections (reconciliation, backups).

### 4. Authenticated instance communication (GHSA-7qwx-x8ff-3px9)
**Operator 1.29+** — Operator-to-instance-manager calls require ECDSA certificate authentication.
**Impact: ✅ Low** — automatic after upgrade; no user configuration needed.

### 5. DatabaseRole CRD
**Operator 1.28+** — New CRD `DatabaseRole` for declarative PostgreSQL role management.
**Impact: ✅ None** — no `DatabaseRole` resources are created yet. Available for future GitOps use.

### 6. Primary Lease (`.spec.primaryLease`)
**Operator 1.30+** — Kubernetes Lease-based mutex for safe primary election (opt-in).
**Impact: ✅ None** — not configured on any cluster.

## Impact on Current Setup

| Change | Affected? | Details |
|---|---|---|
| Cluster reference immutability (CEL) on `Database`/`Pooler`/`Publication`/`Subscription`/`ScheduledBackup` | ⚠️ AFFECTED (no current impact) | No such resources exist today, but if any are created with a wrong `cluster` reference they will fail on update — use correct `.spec.cluster.name` from creation |
| SCRAM-SHA-256 password encoding (CVE-2026-55765) | ❌ Not affected | Backward compatible; opt-out via `kubectl annotate cluster <name> cnpg.io/passwordPassthrough=true` if needed — no clusters use non-default `password_encryption` |
| `search_path` pinning (CVE-2026-55769) | ✅ Transparent security fix | Affects operator-internal connections only (reconciliation, backups) — no application impact |
| Authenticated instance communication (GHSA-7qwx-x8ff-3px9) | ✅ Transparent security fix | Automatic after upgrade — ECDSA certs generated by operator, no user config needed |
| DatabaseRole CRD | ❌ Not affected | New capability, not yet used — available for future GitOps role management |
| Primary Lease (`.spec.primaryLease`) | ❌ Not affected | Opt-in; not configured on any cluster |
| Operator version 1.27.x → 1.30.0 | ✅ Minor bump | PostgreSQL 18.4 default, K8s 1.36 support, VPA/HPA targetRef, in-place pg_upgrade — all additive features |

**Post-upgrade verification** — After all pods settle:
```bash
kubectl get clusters -A
kubectl get pods -n cnpg
kubectl get pods -n immich -l cnpg.io/cluster=immich-database
kubectl get pods -n authentik -l cnpg.io/cluster=authentik-database
kubectl get pods -n maistokainos -l cnpg.io/cluster=maistokainos-database
```

## Upgrade procedure

1. **Merge and sync** — ArgoCD applies the new chart version and CRDs.
2. **Operator rollout** — The `cloudnative-pg` Deployment rolls to v1.30.0. CRDs are updated.
3. **Automatic rolling update** — Each PostgreSQL cluster reconciles with the new operator, triggering a rolling restart + automatic switchover (unsupervised).
4. **Verify** — After all pods settle:
   ```bash
   kubectl get clusters -A
   kubectl get pods -n cnpg
   kubectl get pods -n immich -l cnpg.io/cluster=immich-database
   kubectl get pods -n authentik -l cnpg.io/cluster=authentik-database
   kubectl get pods -n maistokainos -l cnpg.io/cluster=maistokainos-database
   ```

## Changelog (operator 1.27.x → 1.30.0)

### Features
- **DatabaseRole CRD** — Declarative PostgreSQL role management as standalone Kubernetes objects (GitOps-friendly)
- **Primary Lease** — Kubernetes Lease-based mutex for safe primary election (`.spec.primaryLease`)
- **PgBouncer image catalogs** — Pooler can reference ImageCatalog/ClusterImageCatalog entries
- **TLS for Pooler metrics** — HTTPS metrics endpoint via `.spec.monitoring.tls.enabled`
- **VPA/HPA support** — Cluster becomes a valid targetRef via `status.selector`
- **In-place pg_upgrade with Image Volume extensions** — PostgreSQL 19+ support
- Kubernetes 1.36 support, default PostgreSQL updated to 18.4

### Security
- CVE-2026-55769 — search_path pinning
- CVE-2026-55765 — SCRAM-SHA-256 password encoding
- GHSA-7qwx-x8ff-3px9 — authenticated operator-to-instance-manager calls

### Notable Fixes
- Fixed backup stuck in `pending` forever
- Fixed switchover deadlock with WAL-archiver plugins
- Fixed race conditions in bootstrap recovery
- Fixed concurrent backup resource leaks
- Fixed atomic certificate file writes

## Source

https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.30.0