### PR TITLE
chore(deps): k8s-gateway 3.2.7 → 3.7.2

### DIFF
--- a/apps/k8s-gateway/kustomization.yaml
+++ b/apps/k8s-gateway/kustomization.yaml
@@ -8,6 +8,6 @@ helmCharts:
   - name: k8s-gateway
     repo: https://k8s-gateway.github.io/k8s_gateway/
     namespace: kube-system
-    version: 3.2.7
+    version: 3.7.2
     releaseName: excoredns
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| k8s-gateway | 3.2.7 | -> | 3.7.2 | Yellow |

## Breaking Changes / Upgrade Notes

### serviceLabelSelectors (OR-of-ANDs) -- Potential

- **Chart 3.7.0** introduced `filters.serviceLabelSelectors` as an array of label maps (OR-of-ANDs), replacing the single `serviceLabelSelector` map from earlier chart versions.
- **Format**: `serviceLabelSelectors` is `[]map[string]string` -- each entry is a label AND-match, and the array entries are OR-ed together.
- **Impact on this deployment**: None. The current `values.yaml` does not set any `serviceLabelSelector`, so there is nothing to migrate. No values change required.

### EndpointSlice RBAC -- Non-breaking

- **Chart 3.7.2** adds a ClusterRole rule allowing `list`/`watch` on `discovery.k8s.io/endpointslices`.
- This enables opt-in headless service endpoint resolution but does nothing by default.
- **Impact**: Safe. The new RBAC rule is additive and does not affect existing behavior.

### Headless Service Resolution -- Non-breaking

- **Chart 3.7.2** adds support for resolving headless service endpoints individually via EndpointSlice data.
- Only activates when `endpointResolution: enabled` is set in the app config (opt-in).
- **Impact**: Safe. Not enabled by default; no change needed in values.yaml.

### App Version Bump

- **Current (chart 3.2.7)**: appVersion `1.6.0`
- **Target (chart 3.7.2)**: appVersion `1.8.0`
- Includes CoreDNS, Kubernetes client library, and Gateway API dependency upgrades across the intermediate releases.
- **Note**: The chart values.yaml default image tag is `1.7.0`, but the chart metadata states appVersion `1.8.0`. After deploy, verify the running image tag matches expectations.

### Values.yaml Compatibility

The current `values.yaml` uses only:
- `domain`, `watchedResources`, `service.loadBalancerIP`, `service.annotations`, `replicaCount`

All of these fields are **fully compatible** with chart 3.7.2 -- no structural changes, no renames, no removals. The new chart adds new optional fields (e.g., `filters`, `scheme`, `podAnnotations`) but does not remove or break existing ones.

## Impact on Current Setup

| Change | Affected? | Details |
|---|---|---|
| `serviceLabelSelectors` OR-of-ANDs format | ❌ Not affected | `values.yaml` does not set any `serviceLabelSelector` — nothing to migrate |
| EndpointSlice RBAC (ClusterRole rule) | ❌ Not affected | Opt-in only; no existing RBAC changes needed |
| Headless service endpoint resolution | ❌ Not affected | Opt-in (`endpointResolution: enabled`) — not enabled, no headless services in use |
| App version bump 1.6.0 → 1.8.0 | ✅ Minor bump | Includes CoreDNS, K8s client library, and Gateway API dep upgrades — upstream-tested across releases |
| `values.yaml` schema | ✅ Fully compatible | All current fields (`domain`, `watchedResources`, `service.*`, `replicaCount`) remain valid in chart 3.7.2 |

**Verified against** `apps/k8s-gateway/values.yaml`: uses `domain`, `watchedResources` (Ingress/Service/HTTPRoute), `service.loadBalancerIP`, `service.annotations`, `replicaCount` — all forward-compatible. No changes required.

## Intermediate Versions (3.2.7 -> 3.7.2)

### k8s-gateway-3.2.8
- update to newer app version (appVersion 1.6.0, likely container tag bump)

### k8s-gateway-3.3.0
- allow setting `loadBalancerClass` on Service

### k8s-gateway-3.4.0
- add scheme configuration option to enable DoT/DoH/gRPC protocols (appVersion 1.6.1)

### k8s-gateway-3.4.1
- container image tag updated to 1.6.2 from 1.6.1

### k8s-gateway-3.4.2
- container image tag updated to 1.6.4 from 1.6.2

### k8s-gateway-3.6.0
- appVersion from 1.6.4 to 1.7.0 (includes Node hostname DNS resolution)

### k8s-gateway-3.6.1
- add project URL to chart metadata

### k8s-gateway-3.7.0
- support multiple `serviceLabelSelectors` for OR-of-ANDs filtering (app v1.8.0 features)

### k8s-gateway-3.7.1
- bump app version to 1.8.0

### k8s-gateway-3.7.2
- RBAC permission to list/watch `discovery.k8s.io/endpointslices` for opt-in endpoint resolution
- Headless service endpoint resolution support

## Risk Assessment

| Risk Area | Assessment |
|---|---|
| serviceLabelSelectors format change | Not used -- no migration needed |
| New EndpointSlice RBAC | Additive -- no change in behavior |
| CoreDNS dep upgrades | Upstream, tested across releases |
| values.yaml schema | All current fields are forward-compatible |
| Image default tag | Chart default is 1.7.0 but appVersion claims 1.8.0 -- verify after deploy |

## Source

https://github.com/k8s-gateway/k8s_gateway/releases