### PR TITLE
chore(deps): k8up 4.8.6 → 4.9.0

### DIFF
--- a/apps/backup/kustomization.yaml
+++ b/apps/backup/kustomization.yaml
@@ -8,10 +8,10 @@ helmCharts:
   - name: k8up
     repo: https://k8up-io.github.io/k8up
     namespace: backup
-    version: 4.8.6
+    version: 4.9.0
     releaseName: k8up
     valuesFile: values.yaml
 
 resources:
   - sealed-secret.yaml
-  - https://github.com/k8up-io/k8up/releases/download/k8up-4.8.6/k8up-crd.yaml
+  - https://github.com/k8up-io/k8up/releases/download/k8up-4.9.0/k8up-crd.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| k8up | 4.8.6 | → | 4.9.0 | 🟡 |

## Breaking Changes / Upgrade Notes

The bundled K8up operator version changes the system requirements — see [supported Kubernetes versions](https://docs.k8up.io/k8up/2.15/explanations/system-requirements.html#_supported_kubernetes_versions).

If application-aware backups fail after upgrade, add to `values.yaml`:

```yaml
k8up:
  envVars:
    - name: INSECURE_ALLOW_PODEXEC_SPDY_FALLBACK
      value: "true"
```

See [#1183](https://github.com/k8up-io/k8up/pull/1183) for context.

## Changelog

### k8up-4.8.7 (Helm chart changes only)

**Features**
- helm chart: allow setting resources on the cleanup job/hook ([#1091](https://github.com/k8up-io/k8up/pull/1091))
- Bump Chart version ([#1148](https://github.com/k8up-io/k8up/pull/1148))

### k8up-4.9.0 (Helm chart changes only)

**Features**
- Add nodeSelector, tolerations, and affinity to cleanup hook ([#1175](https://github.com/k8up-io/k8up/pull/1175))

**Fixes**
- Fix globalResources env var names in Helm chart ([#1168](https://github.com/k8up-io/k8up/pull/1168))
- Use websockets instead of SPDY for streaming ([#1183](https://github.com/k8up-io/k8up/pull/1183))

**Dependency Updates**
- Bump chart version ([#1185](https://github.com/k8up-io/k8up/pull/1185))

## Source

https://github.com/k8up-io/k8up/releases/tag/k8up-4.9.0