### PR TITLE
chore(deps): descheduler release-1.35 → release-1.36

### DIFF
--- a/apps/descheduler/kustomization.yaml
+++ b/apps/descheduler/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: kube-system
 
 resources:
-  - github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.35
+  - github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.36
 
 patches:
   - path: cronjob-patch.yaml

--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| descheduler | release-1.35 | → | release-1.36 | 🟢 |

## Breaking Changes / Upgrade Notes

No breaking changes between v0.35.0 and v0.36.0.

## Changelog

### What's Changed (v0.36.0)

- fix(ci): pin helm-unittest plugin version and bump chart-testing action by @a7i
- Update helm RBAC to account for pvc failure on 0.35.0 by @cayla
- Add init containers support to Helm chart by @kamleshjoshi8102
- Change icon URL in Chart.yaml by @a7i
- fix: resolve detected data races by @ingvagabund
- fix(ci): upgrade codeql-action to v4 and clean up security workflow by @a7i
- update golang semconv dependencies by @sammedsingalkar09
- Extend PodLifeTime with condition, exit code, owner kind, and transition time filters by @a7i
- security: Update trivy-action to use sha for v0.35.0 by @Priyankasaggu11929
- security: upgrade grpc and otel sdk dependencies by @sammedsingalkar09
- evictions: fix missing observability for background evictions by @tiraboschi
- fix(descheduler): reset prometheus usage client at each extension point by @tiraboschi
- fix(.github/workflows/manifests.yaml): pin actions to a sha by @ingvagabund
- cloudbuild: pin gcb-docker-gcloud image by digest by @Paramesh324
- chart: allow overriding ServiceMonitor apiVersion by @a7i
- ci: pin GitHub Actions to immutable SHAs by @a7i
- evictions: fix assumePod silently dropping success metric on informer race by @tiraboschi
- chore(defaultevictor): add MatchExpressions compatibility to the namespaceselector by @Fankhauserli
- fix(test/setupTestSandbox): wait until initial objects are propagated to informers by @ingvagabund
- [v0.36.0] release prep: bump k8s/go deps, manifests, docs, and CI matrix by @a7i

**Full Changelog**: https://github.com/kubernetes-sigs/descheduler/compare/v0.35.0...v0.36.0

## Source

https://github.com/kubernetes-sigs/descheduler
