### PR TITLE
chore(deps): grafana-operator 5.21.4 → 5.24.0

### DIFF
--- a/apps/observability/grafana-operator/kustomization.yaml
+++ b/apps/observability/grafana-operator/kustomization.yaml
@@ -9,11 +9,11 @@ helmCharts:
   - name: grafana-operator
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 5.21.4
+    version: 5.24.0
     releaseName: grafana-operator
     valuesFile: values.yaml
 
 resources:
-  - https://github.com/grafana/grafana-operator/releases/download/v5.21.4/crds.yaml
+  - https://github.com/grafana/grafana-operator/releases/download/v5.24.0/crds.yaml
   - grafana.yaml
   - sealed-secret.yaml

--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| grafana-operator | 5.21.4 | -> | 5.24.0 | yellow |

## Breaking Changes / Upgrade Notes

- **Skip intermediate releases**: Due to CRD incompatibilities, the upstream recommends updating directly from 5.21.x to 5.24.0, skipping 5.22.0 and 5.22.1.
- **Cache strategy default changed** (5.22.0): The default fallback for the cache strategy changed from `off` to `safe`. If you haven't explicitly set `enforceCacheLabels` to null, this does not affect you.
- **Grafana 13.0.1 default** (5.23.0): Default Grafana version bumped to 13.0.1. Existing instances are not automatically updated -- modify `.spec.version` to upgrade.
- **Grafana >=13 gzip disabled** (5.23.0): Gzip compression is now disabled by default for Grafana >= 13.
- **emptyDir for /tmp** (5.22.1): Plugin downloads now use an emptyDir-backed `/tmp` volume instead of `TMPDIR` env (which is ignored by Grafana >= 12.4.0).
- **Pre-provisioned receivers deprecated** (5.22.1): Starting in Grafana 12.4.0+, pre-provisioned receivers (`default-receiver`, `grafana-default-email`) are deprecated. Migrate to `GrafanaContactPoint` CR.
- **Leader election RBAC fix** (5.22.1): RBAC manifests updated to include core API group for LeaderElection events.
- **No known breaking changes from 5.x overall** -- updates should be trivial.

## Changelog

### v5.24.0 (Jun 9, 2026)

**Features:**
- Add Generic API reconciler for managing previously unsupported Grafana resources
- Add OCI artifact source for dashboard and library panel content

**Fixes:**
- Fix AlertRuleGroup query model normalization before drift compare
- Fix jsonnet imports using os.Root
- Important security fix -- update ASAP

**Security:**
- Update `golang.org/x/crypto` to v0.52.0
- Update `golang.org/x/net` to v0.55.0

### v5.23.0 (May 21, 2026)

**Features:**
- Update Grafana Deployment when referenced Secret/ConfigMap contents change
- Make leader election optional (OLM)
- Feature flag API
- Allow setting `ipFamilyPolicy` in helm chart
- Disable gzip compression in Grafana >= 13

**Fixes:**
- NamespaceScope RBAC avoids ClusterRole
- Make `tenantNamespace` optional
- Do not propagate applyset labels to child resources
- Handle corrupted cache
- Fix matchExpressions for instances with no labels
- Limit GVR resolving to correct kind

### v5.22.2 (Mar 17, 2026)

**Fixes:**
- Escape reserved identifiers in CEL rules for k8s < 1.32 compatibility
- Fix incomplete CEL for namespace immutability check in GrafanaManifest

### v5.22.1 (Mar 13, 2026)

**Fixes:**
- Fix LeaderElection events generation (RBAC)
- Fix `--zap-devel=true` not enabling debug logs
- Fix tmp dir permissions for plugin installation in Grafana 12.4.0+
- Remove extra rolebinding with `namespaceScope=true` without `watchNamespaces`
- Bump default Grafana to 12.4.0

### v5.22.0 (Feb 24, 2026)

**Features:**
- **New CRD: `GrafanaManifest`** -- manage previously unsupported Grafana API resources (Playlists, ShortURLs, plugin resources)
- Dynamic resource patching with jq for GrafanaManifest
- AlertRuleGroup: `targetDatasourceUid` for recording rules, `active_time_intervals` in notificationSettings
- GrafanaServiceAccount: `.spec.name` made optional (defaults to `metadata.name`)

**Changes:**
- Default cache strategy changed from `off` to `safe`

## Source

https://github.com/grafana/grafana-operator/releases/tag/v5.24.0
