### PR TITLE
chore(deps): immich 0.10.3 → 0.12.0

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: immich
     repo: https://immich-app.github.io/immich-charts
     namespace: immich
-    version: 0.10.3
+    version: 0.12.0
     releaseName: immich
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| immich | 0.10.3 | -> | 0.12.0 | :yellow_circle: |

## Breaking Changes / Upgrade Notes

This update spans two chart versions and includes the following changes:

**Chart 0.11.0** (Mar 27, 2026) brought:
- Immich app version bump: **v2.0.0 -> v2.6.3**
- Common Helm library: 4.4.0 -> 4.6.2
- New feature: option to store configuration in a Secret (`immich.configurationKind`)
- New feature: option to use existing externally-managed config (`immich.existingConfiguration`)
- fix(service): added `appProtocol: websocket` for health/version checks
- Various dependency updates

**Chart 0.12.0** (May 15, 2026) brought:
- Common Helm library: 4.6.2 -> **5.0.1** (major bump -- see below)
- CI/workflow improvements
- Dependency updates (tilt, ctlptl, kubectl, helm, valkey)

No appVersion change between 0.11.0 and 0.12.0 (both v2.6.3).

No database migration steps required.

### Common Library 5.x Breaking Changes

The common library bump from 4.x to 5.x introduces several breaking changes in the underlying templates:

- **RawResources restructured** -- K8s manifests now use a `manifest` wrapper key instead of `spec`. Not applicable here since immich doesn't use rawResources.
- **`automountServiceAccountToken` now defaults to `false`** -- if immich server needs token access (e.g. for Kubernetes API), this must be explicitly enabled.
- **Unprivileged serviceAccount created by default** -- can be disabled with `global.createDefaultServiceAccount: false`.
- **ServiceMonitor/PodMonitor `jobLabel` defaults to `app.kubernetes.io/name`** -- review if any custom monitoring relies on the previous default.
- **Minimum Kubernetes version: 1.31** (our cluster is on 1.32 -- compatible)
- **Minimum Helm version: 3.18** (handled by ArgoCD)

### Config-in-Secret Feature

Chart 0.11.0+ supports storing Immich configuration in a Kubernetes Secret instead of a ConfigMap via `immich.configurationKind: Secret`. This is **opt-in** -- the chart continues to create a ConfigMap by default (`configurationKind: ConfigMap`), so no changes to `values.yaml` are required for backwards compatibility. To use it, add:

```yaml
immich:
  configurationKind: Secret
```

## Impact on Current Setup

| Check | Status | Notes |
|---|---|---|
| Common Helm library 4.4.0 → 5.0.1 (major) | 🟢 Compatible | `values.yaml` uses common library keys (`controllers`, `service`, `pod`, `affinity`, `env`) whose structure is unchanged between 4.x and 5.x. |
| App version v2.0.0 → v2.6.3 (major) | 🟡 Review recommended | Image tag in `values.yaml` is pinned to **v2.5.6** — chart default is v2.6.3. Consider bumping or unpinning to get latest features/patches. |
| `automountServiceAccountToken` default `false` | 🟢 Not affected | Immich server uses DB credentials via env vars, not Kubernetes API. No service account token needed. |
| Unprivileged serviceAccount by default | 🟢 Not affected | No custom service account configuration to break. |
| ServiceMonitor/PodMonitor `jobLabel` change | 🟢 Not affected | No custom ServiceMonitor or PodMonitor resources in this deployment. |
| Min K8s 1.31 / Helm 3.18 | 🟢 Compatible | Cluster is on 1.32, ArgoCD handles Helm version. |
| `immich.configurationKind` (ConfigMap→Secret) | 🟢 Opt-in only | Not set — defaults to ConfigMap. No action required. |
| Valkey persistence disabled | 🟢 Compatible | `valkey.persistence.data.enabled: false` works in chart 0.12.0. |
| Hardware transcoding (`privileged: true`) | 🟢 Compatible | `server.securityContext.privileged: true` for `/dev/dri` access remains valid. |
| `values.yaml` overall | 🟢 No structural changes needed | All current keys valid through chart 0.12.0. |

### Recommended Follow-up

- **Bump `tag: v2.6.3`** in `values.yaml` to align with the chart's default app version, unless v2.5.6 is intentionally pinned.
- Consider enabling `immich.configuration` and setting `immich.configurationKind: Secret` if using Immich's config file for sensitive settings.

## Changelog

**immich-0.11.0:** https://github.com/immich-app/immich-charts/releases/tag/immich-0.11.0
- refactor: add option to store configuration in a secret ([#296](https://github.com/immich-app/immich-charts/pull/296))
- feat: add option to use existing config not managed by the chart ([#307](https://github.com/immich-app/immich-charts/pull/307))
- fix(service): Add service appProtocol websocket ([#323](https://github.com/immich-app/immich-charts/pull/323))
- chore: deprecate http repo ([#326](https://github.com/immich-app/immich-charts/pull/326))
- chore(deps): bump Immich version to v2.6.3 ([#327](https://github.com/immich-app/immich-charts/pull/327))
- chore(deps): update helm release common to v4.5.0 -> v4.6.2
- chore(deps): update helm to v4
- chore(deps): various dependency updates

**immich-0.11.1** (Mar 31, 2026) -- fix: bump tag in values ([#336](https://github.com/immich-app/immich-charts/pull/336))

**immich-0.12.0:** https://github.com/immich-app/immich-charts/releases/tag/immich-0.12.0
- chore: group testing dependencies ([#330](https://github.com/immich-app/immich-charts/pull/330))
- chore: switch push-o-matic auth from app-id to client-id ([#345](https://github.com/immich-app/immich-charts/pull/345))
- chore(deps): update helm release common to v5 ([#348](https://github.com/immich-app/immich-charts/pull/348)) -- breaking changes in common library 5.x (see above)
- fix: use matchDepNames for test deps group ([#347](https://github.com/immich-app/immich-charts/pull/347))
- fix: update versioned common chart links ([#350](https://github.com/immich-app/immich-charts/pull/350))
- chore(deps): various dependency updates

## Source

https://github.com/immich-app/immich-charts/releases/tag/immich-0.12.0
