### PR TITLE
chore(deps): pyroscope 1.15.1 → 2.1.0

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.15.1
+    version: 2.1.0
     releaseName: pyroscope
     valuesFile: values.yaml
 

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | Target | Risk |
|---|---|---|---|
| pyroscope | 1.15.1 | 2.1.0 | high |

## Breaking Changes / Upgrade Notes

This is a **major version jump** (1.x → 2.x) with significant breaking changes in the Helm chart values and the underlying Pyroscope storage architecture.

### Helm chart 2.0.0 breaking changes (applies to 2.1.0)

1. **`architecture.storage` replaces `all.enable-v1-write-path` / `all.enable-v1-read-path`** - The old flags are removed. Use `architecture.storage.v1` and `architecture.storage.v2` booleans instead.
2. **`persistence.shared` removed** - This Helm value no longer exists.
3. **`migration.queryBackend` removed** - Use the new `architecture.storage.migration.queryBackend` path instead.
4. **v2 storage architecture becomes the default** - Chart 2.1.0 defaults to the v2 write path (segment-writer) which writes directly to object storage. If you need the v1 ingester path, set `architecture.storage.v1: true` and `architecture.storage.v2: false`.
5. **Label sanitization disabled by default** - UTF-8 label names with dots are now accepted as-is. Set `-validation.disable-label-sanitization=false` to restore previous behavior.
6. **Default filesystem paths moved** - v2 data paths are now under `./data/v2/`.

### Upgrade impact for this deployment
- Our `values.yaml` does not use any of the deprecated values (`all.enable-v1-write-path`, `persistence.shared`, `migration.queryBackend`), so no values changes are required.
- The `pyroscope.persistence.existingClaim: pyroscope-pvc` remains valid.
- The v2 architecture defaults to filesystem storage backend, which works with the existing PVC in single-binary mode.
- After upgrade, the chart will default to `architecture.storage.v2: true` (v2-only), which means the existing PVC will be used for the filesystem-based v2 storage.

**Review the v1 to v2 migration guide (https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/) before deploying.**

## Changelog

### pyroscope-2.1.0 (Jun 17, 2026)

#### Enhancements
- **distributor**: Add readiness checks
- **debuginfo**: Add list and delete APIs, including `profilecli` support
- **segment-writer**: Build dataset indexes in segments
- **metastore**: Add cache hit and miss metrics
- **distributor**: Add ingest parse duration histogram metrics
- **query-backend**: Add per-tenant, per-query bytes-fetched metrics
- **query-frontend**: Add estimation accuracy histogram metrics
- Add per-tenant limits for number of recording rules
- **Helm**: Default to v2 storage architecture
- **Helm**: Add `extraObjects` for deploying extra Kubernetes manifests
- **Monitoring**: Migrate dashboards to native histograms

#### Fixes
- Fix out-of-bounds panic in `clearAddresses`
- Fix nil matcher handling for recording rule upserts
- **store-gateway**: Validate tenant IDs
- Fix archive extraction issues (zip-slip/tar-slip cleanup)
- Fix label value cloning to avoid buffer reuse-after-free
- **query-backend**: Restore original start time for `RangeSeries` bucketing
- **read path**: Reject sub-millisecond `step` parameters
- Fix panic on unknown `QueryNode` types
- **store-gateway**: Restore ring info route from `/tenants` to `/ring`
- **speedscope**: Return error instead of panicking for unknown unit values
- **metastore**: Version shard cache reads
- **compaction-worker**: Correct `time_to_compaction_seconds` histogram buckets
- **Helm**: Add `apiVersion` and `kind` to `volumeClaimTemplates`

#### Security fixes
- **ui**: Update Vite to v8.0.16
- **ui**: Bump `tar`, `js-yaml`, and `@babel/core`
- **ui**: Bump `uuid` from 11.1.0
- **ui**: Patch CVE-2026-45149 and CVE-2026-46625
- Update `golang.org/x/net` to v0.53.0
- Update `golang.org/x/crypto` to v0.52.0
- Update `golang.org/x/image` to v0.41.0
- Update `github.com/prometheus/prometheus` to v0.311.3
- Update Go toolchain to v1.25.11

### pyroscope-2.0.0 (major - first v2 release)
- v2 storage architecture becomes the default
- Go module path bumped to `github.com/grafana/pyroscope/v2`
- Default write path flipped from `ingester` to `segment-writer`
- Default storage backend flipped to `filesystem`
- New `-architecture.storage` flag (v1, v1-v2-dual, v2), default `v1-v2-dual`
- Label sanitization disabled by default
- Helm chart restructured (see Breaking Changes above)

## Source

https://github.com/grafana/helm-charts/releases