### PR TITLE
chore(deps): tempo 1.23.3 → 1.24.4

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/tempo/kustomization.yaml
+++ b/apps/observability/tempo/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: tempo
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.23.3
+    version: 1.24.4
     releaseName: tempo
     valuesFile: values.yaml
 

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| tempo | 1.23.3 | → | 1.24.4 | 🟡 |

## Breaking Changes / Upgrade Notes

This chart bump upgrades Tempo from **2.8.2** → **2.9.0** (chart 1.23.3 → 1.24.4).

### Tempo 2.9 upgrade considerations

- **Bucket calculation changes**: TraceQL metrics buckets are now calculated based on data in the past instead of the future, aligning with Prometheus. May cause differences in existing dashboards and alerts relying on TraceQL metrics bucket calculations.
- **Series label handling improvements**: The `prom_labels` field has been removed from TraceQL metrics responses to fix incorrect results when series labels include both strings and integers with the same textual representation (e.g. `"500"` vs `500`). Brief interruptions to TraceQL metrics queries possible during rollout.
- **vParquet5 block format** (experimental): New experimental block format with breaking changes expected before final release. Not enabled by default.
- **Go version upgrade**: Tempo 2.9 upgrades to Go 1.25.0.
- **RPM/DEB packages discontinued**: Not relevant for our Helm-based deployment.
- **Vulture/integration tests migrated to OTLP exporter**: Not relevant for our deployment.

### Chart-level changes (1.23.3 → 1.24.4)

No chart-level breaking changes apply — we are already past the 1.21.1 (port 3100→3200) and 1.17.0 (Tempo 2.7) breaking changes. This is a minor bump within the 1.24.x series.

## Changelog

### Tempo 2.9 Highlights
- **MCP (Model Context Protocol) server**: Experimental LLM integration for querying tracing data via TraceQL
- **TraceQL metrics sampling**: Adaptive probabilistic sampling via `with(sample=true)` for improved performance
- **SLO metrics improvements**: Cached querier responses excluded from SLO metrics
- **New metrics**: `query_frontend_bytes_inspected_total`, `spans_distance_in_future/past_seconds`, `tempo_distributor_ingress_bytes_total`
- **Metrics-generator improvements**: Invalid Prometheus label names auto-dropped, `db.namespace` attribute support, improved service graph virtual nodes
- **TraceQL performance improvements**: Batch processing optimizations, complex query improvements, `compare()` function optimization
- **Security fixes**: Multiple CVE patches (Go, OTel SDK, gRPC, x/crypto, expr-lang, etc.)
- **Project Rhythm**: New architecture foundation (Kafka-based, live-store, block-builder)

### Chart versions between 1.23.3 and 1.24.4
- **1.24.0** (Oct 26, 2025) — Tempo 2.9.0
- **1.24.1** (Nov 21, 2025) — Tempo 2.9.1 (security fixes)
- **1.24.2** (Jan 12, 2026) — Tempo 2.9.2 (security fixes)
- **1.24.3** (Jan 13, 2026) — Patch
- **1.24.4** (Jan 30, 2026) — Final chart release in grafana/helm-charts (chart migrated to grafana-community/helm-charts after this)

## Source

https://github.com/grafana/helm-charts/releases