### PR TITLE
chore(deps): authentik 2026.2.2 → 2026.5.4

### DIFF
--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   - name: authentik
     repo: https://charts.goauthentik.io
     namespace: authentik
-    version: 2026.2.2
+    version: 2026.5.4
     releaseName: authentik
     valuesFile: values.yaml
 

--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| authentik | 2026.2.2 | → | 2026.5.4 | 🟡 |

## Breaking Changes / Upgrade Notes

### Listening on multiple IPs
The default listen IP changed from `0.0.0.0` to `[::]` (IPv6 dual-stack). Some IPv4-only environments might need to adapt listening settings.

### Application Dashboard migration
The "My applications" page has been renamed to "Application Dashboard". Apps previously hidden via `blank://blank` launch URL are automatically migrated to the new **Hide from Application Dashboard** toggle.

### SAML provider issuer
Issuer URLs are now auto-generated. The `issuer` field has been replaced by `issuer_override` in the API. Existing configurations are migrated automatically.

### SAML unified endpoints
Individual login/logout endpoints for redirect/post are now consolidated into a single SAML endpoint.

### New Rust worker entrypoint
The worker now starts through a Rust entrypoint, dropping ~200 MB memory usage per worker container and one fewer PostgreSQL connection per worker.

### OAuth2 configurable grant types
New **Grant Types** setting on OAuth2 providers. Existing providers default to all grant types enabled for backward compatibility.

### Removed dependencies
17 packages removed from authentik, reducing attack surface.

## Changelog

### ✨ Highlights (2026.5.0)
- **Account Lockdown** (Enterprise): Panic button for compromised accounts to cut off access, revoke tokens, end sessions
- **Conditional Access** (Enterprise): New Fleet certificate and Google Chrome Device Trust connectors
- **AKQL now open source**: Previously enterprise-only search query language is now free for all
- **Command Palette**: New `Cmd+K` palette for quick UI navigation
- **Performance**: Rust worker entrypoint saves ~200 MB RAM per worker container
- **WebAuthn Client Hints**: Support for WebAuthn Level 3 `hints` parameter
- **2FA attempt throttling**: Brute-force protection extended to email/SMS OTP
- **Import hashed passwords**: Bootstrap with pre-hashed Django passwords
- **OAuth2 configurable grant types**: Explicit grant type selection per provider

### 🐛 Fixed in 2026.5.1–2026.5.4
- Fix invitation emails ignoring selected template
- Fix paused schedules getting unpaused on startup
- Fix passkey autofill not showing on identification stage
- Fix race condition in broker causing repeated completed tasks
- Fix OAuth post logout redirect matching
- Fix missing tenant in setup migration
- Fix stale clipboard tokens and untranslated labels
- Fix SCIM discovery failures for users with no email
- Fix Avatar URL encoding preservation
- Fix server-side message race condition
- Fix LDAP connection re-creation and optimization
- Fix OAuth error return via POST and request objects
- Fix WebAuthn `prevent_duplicate_devices` default (now disabled by default)
- Add pre_delete for TasksModel to prevent OOM on deletion
- Various dependency bumps and security updates

## Source

https://github.com/goauthentik/authentik/releases/tag/version/2026.5.4