### PR TITLE
chore(deps): grafana 12.1.1 → 12.7.2

### DIFF
--- a/apps/observability/grafana/kustomization.yaml
+++ b/apps/observability/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: grafana
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 12.1.1
+    version: 12.7.2
     releaseName: grafana
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Chart | Current App | -> | Target App | Risk |
|---|---|---|---|---|---|
| grafana | 12.1.1 -> 12.7.2 | 12.1.1 | -> | 13.1.0 | Yellow |

## Upgrade Notes

This is a minor chart version bump within the 12.x line -- no chart-level breaking changes between 12.1.1 and 12.7.2. However, the chart now defaults to **Grafana 13.1.0** (up from 12.1.1), which is a significant application version jump.

### Items to Verify After Deploy

1. **Image renderer token** -- Grafana 13 requires a rendering auth token when using the remote image renderer. The chart auto-generates one via `imageRenderer.token` if left empty (current values.yaml has `imageRenderer.enabled: true` with no explicit token). The auto-generated value will be stored in a Secret. No manual action required, but verify the image renderer connects successfully after upgrade.

2. **Plugins compatibility** -- `grafana-image-renderer` and `grafana-strava-datasource` are installed via the `plugins:` list. Verify both plugins load correctly in Grafana 13. If the chart ships Grafana 13 with core plugins moved out (e.g. `elasticsearch`, `cloudwatch`), consider enabling `shadowBundledPlugins: true` if any such plugins are needed.

3. **Existing values.yaml** -- No deprecated keys found. All current values (`grafana.ini`, `extraSecretMounts`, `hostAliases`, `route`, `persistence`, `plugins`, `admin`, `imageRenderer`, `nodeSelector`) remain valid in chart 12.7.2.

## Impact on Current Setup

| Check | Status | Notes |
|---|---|---|
| Chart-level breaking changes (12.1.1 → 12.7.2) | 🟢 None | No chart-level breaking changes in the 12.x series. All current `values.yaml` keys remain valid. |
| Grafana app version 12.x → 13.1.0 | 🟡 Minor risk | Major app version jump. Verify plugins, dashboards, datasources, and auth work correctly after deploy. |
| Image renderer token | 🟢 Auto-generated | `imageRenderer.enabled: true` set, no explicit `imageRenderer.token`. Chart auto-generates one and stores it in a Secret. Verify image renderer connects post-upgrade. |
| Plugins compatibility | 🟡 Verify after deploy | `grafana-image-renderer` and `grafana-strava-datasource` should load in Grafana 13. Check core plugin migration; `shadowBundledPlugins: true` may be needed if any bundled plugin is missing. |
| `values.yaml` key audit | 🟢 No deprecated keys | All keys confirmed valid through chart 12.7.2. |
| OAuth / Authentik integration | 🟢 No changes expected | `auth.generic_oauth` configuration unchanged between versions. Verify SSO flow post-upgrade. |

### Changelog

Releases between 12.1.1 and 12.7.2 (community chart, https://grafana-community.github.io/helm-charts):

| Chart | App | Date |
|---|---|---|
| 12.7.2 | 13.1.0 | Jul 1, 2026 |
| 12.7.1 | 13.1.0 | Jun 24, 2026 |
| 12.7.0 | 13.1.0 | Jun 24, 2026 |
| 12.6.0 | 13.1.0 | Jun 23, 2026 |
| 12.5.0 | 13.1.0 | Jun 23, 2026 |
| 12.4.9 | 13.0.2 | Jun 22, 2026 |
| 12.4.8 | 13.0.2 | Jun 17, 2026 |
| 12.4.7 | 13.0.2 | Jun 17, 2026 |
| 12.4.6 | 13.0.2 | Jun 16, 2026 |
| 12.4.5 | 13.0.2 | Jun 13, 2026 |
| 12.4.4 | 13.0.1-security-01 | Jun 9, 2026 |
| 12.4.3 | 13.0.1-security-01 | Jun 9, 2026 |
| 12.4.2 | 13.0.1-security-01 | Jun 3, 2026 |
| 12.4.1 | 13.0.1-security-01 | May 24, 2026 |
| 12.4.0 | 13.0.1-security-01 | May 23, 2026 |
| 12.3.3 | 13.0.1-security-01 | May 15, 2026 |
| 12.3.2 | 13.0.1-security-01 | May 14, 2026 |
| 12.3.1 | 13.0.1 | May 12, 2026 |
| 12.3.0 | 13.0.1 | Apr 29, 2026 |
| 12.2.1 | 13.0.1 | Apr 27, 2026 |

Changes include dependency updates, security patches, Helm template improvements, and Grafana app version upgrades across the 12.x line.

## Source

https://grafana-community.github.io/helm-charts
