### PR TITLE
chore(deps): k8s-monitoring 3.8.10 → 4.2.1

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.10
+    version: 4.2.1
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -1,15 +1,15 @@
----
 cluster:
   name: k3s-homelab
 
+# v4: Destinations changed from a list to a map (keyed by name)
 destinations:
-  - name: loki
+  loki:
     type: loki
     url: http://loki-gateway/loki/api/v1/push
-  - name: prometheus
+  prometheus:
     type: prometheus
     url: http://prometheus-operated:9090/api/v1/write
-  - name: tempo
+  tempo:
     type: otlp
     url: http://tempo:4317
     tls:
@@ -20,19 +20,28 @@ destinations:
       enabled: false
     traces:
       enabled: true
-  - name: pyroscope
+  pyroscope:
     type: pyroscope
     url: http://pyroscope:4040
 
+# v4: User-defined collectors with presets (replaces fixed alloy-* names)
+collectors:
+  metrics-collector:
+    presets: [clustered, statefulset]
+  logs-collector:
+    presets: [filesystem-log-reader, daemonset]
+  events-collector:
+    presets: [singleton]
+  receiver-collector:
+    presets: [daemonset]
+  profiles-collector:
+    presets: [privileged, daemonset]
+
 clusterMetrics:
   enabled: true
+  collector: metrics-collector
   global:
     scrapeInterval: 30s
-  node-exporter:
-    enabled: true
-    deploy: true
-    metricsTuning:
-      useDefaultAllowList: false
   kubelet:
     metricsTuning:
       useDefaultAllowList: false
@@ -42,18 +51,31 @@ clusterMetrics:
   apiServer:
     enabled: true
 
+# v4: Host metrics split from clusterMetrics (Linux hosts via Node Exporter)
+hostMetrics:
+  enabled: true
+  linuxHosts:
+    enabled: true
+    metricsTuning:
+      useDefaultAllowList: false
+
 clusterEvents:
   enabled: true
+  collector: events-collector
 
 nodeLogs:
   enabled: true
+  collector: logs-collector
 
-podLogs:
+# v4: podLogs split into podLogsViaLoki / podLogsViaOpenTelemetry
+podLogsViaLoki:
   enabled: true
+  collector: logs-collector
 
 annotationAutodiscovery:
   enabled: true
   scrapeInterval: 30s
+  collector: metrics-collector
 
 autoInstrumentation:
   enabled: true
@@ -90,6 +112,7 @@ autoInstrumentation:
 
 applicationObservability:
   enabled: true
+  collector: receiver-collector
   receivers:
     otlp:
       grpc:
@@ -107,31 +130,23 @@ applicationObservability:
 prometheusOperatorObjects:
   enabled: true
 
-# profiling enabled via annotations:
-# ebpf - profiles.grafana.com/cpu.ebpf.enabled="true"
-# java - profiles.grafana.com/java.enabled="true"
-# pprof - profiles.grafana.com/cpu.scrape: "true"
-# pprof - profiles.grafana.com/cpu.port: port
-# pprof - profiles.grafana.com/cpu.port_name: port_name
-# pprof - profiles.grafana.com/cpu.scheme: scheme
-# pprof - profiles.grafana.com/cpu.container: container
+# v4: Profiling requires explicitly enabling individual profilers
 profiling:
   enabled: true
+  collector: profiles-collector
+  ebpf:
+    enabled: true
+  pprof:
+    enabled: true
+  java:
+    enabled: false
 
-alloy-receiver:
-  enabled: true
-
-alloy-profiles:
-  enabled: true
-
-alloy-metrics:
-  enabled: true
-
-alloy-singleton:
-  enabled: true
-
-alloy-logs:
-  enabled: true
+# v4: Telemetry services are now explicitly deployed (separate from features)
+telemetryServices:
+  kube-state-metrics:
+    deploy: true
+  node-exporter:
+    deploy: true
 
 alloy-operator:
   deploy: true
@@ -139,6 +154,7 @@ alloy-operator:
     enabled: false
 
 integrations:
+  collector: metrics-collector
   cert-manager:
     instances:
       - name: cert-manager
@@ -149,7 +165,7 @@ integrations:
     instances:
       - name: alloy
         labelSelectors:
-          app.kubernetes.io/name: 
+          app.kubernetes.io/name:
             - alloy-logs
             - alloy-metrics
             - alloy-receiver

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| k8s-monitoring | 3.8.10 | → | 4.2.1 | 🔴 |

## Breaking Changes / Upgrade Notes

This is a **major version jump (3.x → 4.x)** — the largest structural update the chart has received. The v3 values file is **not compatible** with v4. Use the [official migration utility](https://grafana.github.io/k8s-monitoring-helm-migrator/) or manually apply the changes below.

### 1. Destinations: List → Map
In v3, destinations were identified by position in a list. In v4, each destination has a unique key, making Helm value merges, `--set` overrides, and GitOps overlays predictable.
- **Before:** `destinations:\n  - name: prometheus\n    type: prometheus`
- **After:** `destinations:\n  prometheus:\n    type: prometheus`

### 2. Collectors: User-defined map with presets (replaces fixed alloy-* names)
The old fixed collector names (`alloy-metrics`, `alloy-logs`, `alloy-singleton`, `alloy-receiver`, `alloy-profiles`) are gone. Define your own collectors with presets:
- `alloy-metrics` → `[clustered, statefulset]`
- `alloy-logs` → `[filesystem-log-reader, daemonset]`
- `alloy-singleton` → `[singleton]`
- `alloy-receiver` → `[daemonset]`
- `alloy-profiles` → `[privileged, daemonset]`

Features are explicitly assigned to a collector via a `collector:` field.

### 3. Cluster metrics split
`clusterMetrics` in v3 handled cluster metrics + host metrics + energy + cost all in one. In v4 this is split:
- `clusterMetrics` — Kubelet, cAdvisor, kube-state-metrics, control plane
- `hostMetrics` — Linux hosts (Node Exporter), Windows hosts, energy (Kepler)
- `costMetrics` — OpenCost

### 4. Telemetry services: Explicit deployment
Backing services (Node Exporter, kube-state-metrics, OpenCost, Kepler) are no longer silently deployed by features. They must be explicitly enabled under `telemetryServices`.

### 5. Pod logs split
`podLogs` with default gather method → `podLogsViaLoki`
`podLogs` with `gatherMethod: filelog` → `podLogsViaOpenTelemetry`

### 6. Profiling: Explicit profiler selection
In v4 you must explicitly enable each profiler:
```yaml
profiling:
  enabled: true
  ebpf:
    enabled: true
  pprof:
    enabled: true
  java:
    enabled: false
```

### 7. Prometheus Operator CRDs no longer bundled
If using `prometheusOperatorObjects`, install CRDs separately via `prometheus-community/prometheus-operator-crds`.

### 8. Extra config moved
`alloy-*.extraConfig` → `collectors.<name>.extraConfig`

## Changelog (3.8.10 → 4.2.1)

### 4.0.0 (2026-03-27)
- **Major restructuring:** Destinations as map, user-defined collectors with presets
- Cluster metrics split into clusterMetrics / hostMetrics / costMetrics
- Telemetry services now explicit (telemetryServices key)
- Pod logs split into podLogsViaLoki / podLogsViaOpenTelemetry
- Prometheus Operator CRDs no longer bundled
- Profiling requires explicit profiler selection
- Alloy Operator based deployment (removed alloy subchart dependency)

### 4.1.x (2026-04 to 2026-06)
- Kubernetes enrichment data processor
- EC2 enrichment data processor
- Database Observability (PostgreSQL, MySQL support)
- Service Integrations extraDiscoveryRules
- OpenShift SecurityContextConstraints improvements
- Platform auto-detection (AKS, GKE, EKS)
- OTLP destination timeout fixes
- Various dependency updates (Alloy, Beyla, OpenCost, kube-state-metrics)

### 4.2.0 (2026-07-02)
- Linux host metrics via Alloy directly (source: alloy, no Node Exporter needed)
- Data Processors framework (custom, kubernetesEnrichment, ec2Enrichment)
- Grafana SDK Injector and Beyla Kubernetes cache as telemetry services
- Fixed OTLP → Prometheus target_info resource attribute dropping

### 4.2.1 (2026-07-08)
- New collector presets: `root`, `host-network`, `host-storage`, `host-cgroup` (deprecating `privileged`)
- Per-instance extraDiscoveryRules for Service Integrations
- Fixed kubeletResource/kubeletProbes extraDiscoveryRules being dropped
- Fixed OTLP service identity derivation for Prometheus-scraped metrics
- Fixed OTLP duplicate label values on target_info
- Default remote config pollFrequency: 5m → 30s

## Source
https://github.com/grafana/helm-charts/releases