### PR TITLE
chore(deps): opentelemetry-operator 0.110.0 → 0.119.0

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.7
+    version: 3.8.10
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/opentelemetry-operator/kustomization.yaml
+++ b/apps/observability/opentelemetry-operator/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: opentelemetry-operator
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts
     namespace: observability
-    version: 0.110.0
+    version: 0.119.0
     releaseName: opentelemetry-operator
     valuesFile: values.yaml
 

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -15,6 +15,16 @@ spec:
     path: apps/observability/loki
     repoURL: https://github.com/gedulis12/homelab
     targetRevision: HEAD
+  ignoreDifferences:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      jsonPointers:
+        - /spec/parentRefs/0/group
+        - /spec/parentRefs/0/kind
+        - /spec/rules/0/backendRefs/0/group
+        - /spec/rules/0/backendRefs/0/kind
+        - /spec/rules/0/backendRefs/0/weight
+        - /spec/rules/0/matches
   syncPolicy:
     automated:
       allowEmpty: true


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| opentelemetry-operator | 0.110.0 | → | 0.119.0 | 🟡 |

## Breaking Changes / Upgrade Notes

**0.116.0**: Removed deprecated `manager.featureGates` (use `manager.featureGatesMap` instead). Setting `manager.featureGates` now fails schema validation.

**0.119.0**: Bumps the operator app version to 0.154.0. Review feature gate configuration — new/removed gates may need updating in values.yaml.

## Changelog

### 0.119.0 (Jul 8, 2026)
- Bump operator to 0.154.0 ([#2294](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2294))

### 0.118.0 (Jun 30, 2026)
- Add make target to keep feature gates in sync ([#2280](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2280))

### 0.117.0 (Jun 23, 2026)
- Add support for `operator.clusterobservability` feature gate ([#2239](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2239))

### 0.116.0 (Jun 22, 2026)
- **BREAKING**: Remove deprecated `manager.featureGates` — use `manager.featureGatesMap` ([#2271](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2271))

### 0.115.1 (Jun 22, 2026)
- Add Helm support for operator manager config file ([#2265](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2265))

### 0.115.0 (Jun 11, 2026)
- Release with operator 0.153.0, correct feature gates ([#2257](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2257))

### 0.114.1 (May 28, 2026)
- Update all CI to helm 4+ ([#2237](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2237))

### 0.114.0 (May 26, 2026)
- Bump version to 0.152.0 ([#2229](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2229))

### 0.113.2 (May 26, 2026)
- Expose pprof port ([#2224](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2224))

### 0.113.1 (May 14, 2026)
- Add tokenreviews ClusterRole permission for metrics auth ([#2189](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2189))

### 0.113.0 (May 13, 2026)
- Bump version to 0.151.0 ([#2197](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2197))

### 0.112.2 (May 12, 2026)
- Add minReadySeconds support for operator deployment ([#2190](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2190))

### 0.112.1 (May 6, 2026)
- Fix VPA updateMode YAML parsing by adding quotes ([#2170](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2170))

### 0.112.0 (May 5, 2026)
- Update operator chart for 0.150.0 ([#2173](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2173))

### 0.111.0 (Apr 29, 2026)
- Bump version to 0.149.0 ([#2164](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2164))

## Source

https://github.com/open-telemetry/opentelemetry-helm-charts/releases