### PR TITLE
chore(deps): k8s-monitoring 3.8.10 → 4.2.1

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.10
+    version: 4.2.1
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -1,15 +1,15 @@
----
 cluster:
   name: k3s-homelab
 
+# v4: Destinations changed from a list to a map (keyed by name)
 destinations:
-  - name: loki
+  loki:
     type: loki
     url: http://loki-gateway/loki/api/v1/push
-  - name: prometheus
+  prometheus:
     type: prometheus
     url: http://prometheus-operated:9090/api/v1/write
-  - name: tempo
+  tempo:
     type: otlp
     url: http://tempo:4317
     tls:
@@ -20,19 +20,28 @@ destinations:
       enabled: false
     traces:
       enabled: true
-  - name: pyroscope
+  pyroscope:
     type: pyroscope
     url: http://pyroscope:4040
 
+# v4: User-defined collectors with presets (replaces fixed alloy-* names)
+collectors:
+  metrics-collector:
+    presets: [clustered, statefulset]
+  logs-collector:
+    presets: [filesystem-log-reader, daemonset]
+  events-collector:
+    presets: [singleton]
+  receiver-collector:
+    presets: [daemonset]
+  profiles-collector:
+    presets: [privileged, daemonset]
+
 clusterMetrics:
   enabled: true
+  collector: metrics-collector
   global:
     scrapeInterval: 30s
-  node-exporter:
-    enabled: true
-    deploy: true
-    metricsTuning:
-      useDefaultAllowList: false
   kubelet:
     metricsTuning:
       useDefaultAllowList: false
@@ -42,18 +51,31 @@ clusterMetrics:
   apiServer:
     enabled: true
 
+# v4: Host metrics split from clusterMetrics (Linux hosts via Node Exporter)
+hostMetrics:
+  enabled: true
+  linuxHosts:
+    enabled: true
+    metricsTuning:
+      useDefaultAllowList: false
+
 clusterEvents:
   enabled: true
+  collector: events-collector
 
 nodeLogs:
   enabled: true
+  collector: logs-collector
 
-podLogs:
+# v4: podLogs split into podLogsViaLoki / podLogsViaOpenTelemetry
+podLogsViaLoki:
   enabled: true
+  collector: logs-collector
 
 annotationAutodiscovery:
   enabled: true
   scrapeInterval: 30s
+  collector: metrics-collector
 
 autoInstrumentation:
   enabled: true
@@ -90,6 +112,7 @@ autoInstrumentation:
 
 applicationObservability:
   enabled: true
+  collector: receiver-collector
   receivers:
     otlp:
       grpc:
@@ -107,31 +130,23 @@ applicationObservability:
 prometheusOperatorObjects:
   enabled: true
 
-# profiling enabled via annotations:
-# ebpf - profiles.grafana.com/cpu.ebpf.enabled="true"
-# java - profiles.grafana.com/java.enabled="true"
-# pprof - profiles.grafana.com/cpu.scrape: "true"
-# pprof - profiles.grafana.com/cpu.port: port
-# pprof - profiles.grafana.com/cpu.port_name: port_name
-# pprof - profiles.grafana.com/cpu.scheme: scheme
-# pprof - profiles.grafana.com/cpu.container: container
+# v4: Profiling requires explicitly enabling individual profilers
 profiling:
   enabled: true
+  collector: profiles-collector
+  ebpf:
+    enabled: true
+  pprof:
+    enabled: true
+  java:
+    enabled: false
 
-alloy-receiver:
-  enabled: true
-
-alloy-profiles:
-  enabled: true
-
-alloy-metrics:
-  enabled: true
-
-alloy-singleton:
-  enabled: true
-
-alloy-logs:
-  enabled: true
+# v4: Telemetry services are now explicitly deployed (separate from features)
+telemetryServices:
+  kube-state-metrics:
+    deploy: true
+  node-exporter:
+    deploy: true
 
 alloy-operator:
   deploy: true
@@ -139,6 +154,7 @@ alloy-operator:
     enabled: false
 
 integrations:
+  collector: metrics-collector
   cert-manager:
     instances:
       - name: cert-manager
@@ -149,7 +165,7 @@ integrations:
     instances:
       - name: alloy
         labelSelectors:
-          app.kubernetes.io/name: 
+          app.kubernetes.io/name:
             - alloy-logs
             - alloy-metrics
             - alloy-receiver


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| k8s-monitoring | 3.8.10 | -> | 4.2.1 | HIGH |

## Impact

This PR migrates the k8s-monitoring Helm chart from **v3 to v4** -- a breaking-change major version with a completely restructured values.yaml. The migration was performed manually against our existing v3 configuration.

### What changed in values.yaml

| Area | v3 (removed) | v4 (added) |
|---|---|---|
| **Destinations** | List `[- name: loki, ...]` | Map `{loki: {type: loki, ...}}` keyed by name |
| **Collectors** | Fixed top-level keys: `alloy-metrics`, `alloy-logs`, `alloy-singleton`, `alloy-receiver`, `alloy-profiles` | User-defined `collectors:` map with 5 collectors using presets |
| **Cluster metrics** | `clusterMetrics` monolithic (kubelet + cAdvisor + node-exporter + api-server) | Split: `clusterMetrics` (kubelet/cAdvisor/api-server) + `hostMetrics` (linuxHosts) |
| **Pod logs** | `podLogs` | `podLogsViaLoki` with explicit `collector:` field |
| **Profiling** | Flat `profiling.enabled` + comment docs | Structured: `ebpf.enabled`, `pprof.enabled`, `java.enabled` |
| **Telemetry services** | Implicitly deployed by features | Explicit `telemetryServices:` (kube-state-metrics, node-exporter) |
| **Feature->collector wiring** | Implicit (feature ran on matching alloy-* pod) | Explicit `collector:` field on every feature |
| **Old alloy-* keys** | `alloy-receiver`, `alloy-profiles`, `alloy-metrics`, `alloy-singleton`, `alloy-logs` | Removed entirely |

### Configuration preserved as-is
- **Auto-instrumentation** (Beyla) -- unchanged eBPF config, routes, discovery rules
- **Application observability** -- OTLP receiver (gRPC + HTTP), span metrics/logs config
- **Prometheus Operator objects** -- enabled (CRDs already installed separately)
- **Alloy operator** -- retained (required by v4)
- **Integration scraping** -- cert-manager, grafana, loki, tempo configs intact

### Items flagged during review

1. **Integrations label selectors need updating**
   The `integrations.alloy` section references old collector names as label selectors:
   ```yaml
   app.kubernetes.io/name:
     - alloy-logs
     - alloy-metrics
     - alloy-receiver
     - alloy-singleton
     - alloy-profiles
   ```
   In v4, collectors are named `metrics-collector`, `logs-collector`, `events-collector`, etc., and their `app.kubernetes.io/name` label is `k8s-monitoring` (the release name). These selectors will not match, so the alloy self-metrics integration will fail to discover targets. Update to use `app.kubernetes.io/name: k8s-monitoring` or filter by `app.kubernetes.io/component`.

2. **No costMetrics configured** -- Not a regression; OpenCost was not deployed in v3 either. Skipped intentionally.

3. **Host metrics via Node Exporter** -- Using `hostMetrics.linuxHosts` (Node Exporter) rather than the newer v4.2+ `source: alloy` direct path. Both are valid; the Node Exporter path was chosen for consistency with our existing stack.

## Impact on Current Setup

### Already migrated
This PR performs the v3→v4 values.yaml migration. See the **Impact** section above for a detailed comparison.

### Key structural changes applied
- **Destinations**: Converted from list (`[- name: loki, ...]`) to map (`{loki: {type: loki, ...}}`)
- **Collectors**: Migrated from fixed top-level keys to user-defined `collectors:` map with presets
- **Cluster metrics**: Split into `clusterMetrics` (kubelet/cAdvisor/api-server) + `hostMetrics` (linuxHosts)
- **Profiling**: Now requires explicit per-profiler enablement (`ebpf.enabled`, `pprof.enabled`, `java.enabled`)

## Breaking Changes Reference

For reference, the full list of v3->v4 structural changes:

### 1. Destinations: List -> Map
In v4, each destination has a unique key, making Helm value merges, `--set` overrides, and GitOps overlays predictable.

### 2. Collectors: User-defined map with presets
The old fixed collector names are gone. Define your own collectors with presets. Features are explicitly assigned to a collector via a `collector:` field.

### 3. Cluster metrics split
- `clusterMetrics` -- Kubelet, cAdvisor, kube-state-metrics, control plane
- `hostMetrics` -- Linux hosts (Node Exporter), Windows hosts, energy (Kepler)
- `costMetrics` -- OpenCost

### 4. Telemetry services: Explicit deployment
Backing services (Node Exporter, kube-state-metrics, OpenCost, Kepler) must be explicitly enabled under `telemetryServices`.

### 5. Pod logs split
`podLogs` with default gather method -> `podLogsViaLoki`
`podLogs` with `gatherMethod: filelog` -> `podLogsViaOpenTelemetry`

### 6. Profiling: Explicit profiler selection
Each profiler (ebpf, pprof, java) must be explicitly enabled.

### 7. Prometheus Operator CRDs no longer bundled
If using `prometheusOperatorObjects`, install CRDs separately via `prometheus-community/prometheus-operator-crds`.

### 8. Extra config moved
`alloy-*.extraConfig` -> `collectors.<name>.extraConfig`

## Changelog (3.8.10 -> 4.2.1)

### 4.0.0 (2026-03-27)
- **Major restructuring:** Destinations as map, user-defined collectors with presets
- Cluster metrics split into clusterMetrics / hostMetrics / costMetrics
- Telemetry services now explicit (telemetryServices key)
- Pod logs split into podLogsViaLoki / podLogsViaOpenTelemetry
- Prometheus Operator CRDs no longer bundled
- Profiling requires explicit profiler selection
- Alloy Operator based deployment (removed alloy subchart dependency)

### 4.1.x (2026-04 to 2026-06)
- Kubernetes enrichment data processor
- EC2 enrichment data processor
- Database Observability (PostgreSQL, MySQL support)
- Service Integrations extraDiscoveryRules
- OpenShift SecurityContextConstraints improvements
- Platform auto-detection (AKS, GKE, EKS)
- OTLP destination timeout fixes
- Various dependency updates (Alloy, Beyla, OpenCost, kube-state-metrics)

### 4.2.0 (2026-07-02)
- Linux host metrics via Alloy directly (source: alloy, no Node Exporter needed)
- Data Processors framework (custom, kubernetesEnrichment, ec2Enrichment)
- Grafana SDK Injector and Beyla Kubernetes cache as telemetry services
- Fixed OTLP -> Prometheus target_info resource attribute dropping

### 4.2.1 (2026-07-08)
- New collector presets: `root`, `host-network`, `host-storage`, `host-cgroup` (deprecating `privileged`)
- Per-instance extraDiscoveryRules for Service Integrations
- Fixed kubeletResource/kubeletProbes extraDiscoveryRules being dropped
- Fixed OTLP service identity derivation for Prometheus-scraped metrics
- Fixed OTLP duplicate label values on target_info
- Default remote config pollFrequency: 5m -> 30s

## Source
https://github.com/grafana/helm-charts/releases

