### PR TITLE
chore(deps): authentik 2026.2.2 → 2026.5.4

### DIFF
--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   - name: authentik
     repo: https://charts.goauthentik.io
     namespace: authentik
-    version: 2026.2.2
+    version: 2026.5.4
     releaseName: authentik
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| authentik | 2026.2.2 | → | 2026.5.4 | 🟡 |

## Breaking Changes & Cross-Reference to Our Deployment

### Listening on multiple IPs (default `0.0.0.0` → `[::]`)
The default listen IP changed from `0.0.0.0` to `[::]` (IPv6 dual-stack). Some IPv4-only environments might need to adapt listening settings.

**Our deployment**: We do not set a custom `server.listen` in `values.yaml`. Our ingress is via HTTPRoute through the Cilium shared gateway (`cilium-shared-gateway/kube-system`), not direct port binding. The listen address change should be transparent since traffic arrives through Ciliums LB/IPAM layer. No action needed unless we were binding directly to host ports.

### Rust worker entrypoint (performance improvement)
The worker now starts through a Rust entrypoint, dropping ~200 MB memory usage per worker container and one fewer PostgreSQL connection per worker. Python still runs the worker logic — only the bootstrap process changes.

**Our deployment**: No values changes required. We use `postgresql.enabled: false` (external CloudNativePG cluster), so the reduced connection count is beneficial but not critical. The memory savings (~200 MB) are a pure upside.

### SAML provider issuer (API change, no values impact)
Issuer URLs are now auto-generated. The `issuer` field has been replaced by `issuer_override` in the API. Existing configurations are migrated automatically.

**Our deployment**: No SAML providers configured in `values.yaml`. No action needed.

### SAML unified endpoints (API change, no values impact)
Individual login/logout endpoints for redirect/post are now consolidated into a single SAML endpoint.

**Our deployment**: No SAML providers configured. No action needed.

### Application Dashboard migration (UI change)
The "My applications" page has been renamed to "Application Dashboard". Apps previously hidden via `blank://blank` launch URL are automatically migrated to the new **Hide from Application Dashboard** toggle.

**Our deployment**: Purely a UI/API change — no values.yaml impact.

### OAuth2 configurable grant types (API change, no values impact)
New **Grant Types** setting on OAuth2 providers. Existing providers default to all grant types enabled for backward compatibility.

**Our deployment**: No OAuth2 provider configuration in `values.yaml`. Managed via API/tooling. No action needed unless we want to restrict grant types for specific providers post-upgrade.

### Removed dependencies (17 packages)
Reduced attack surface. No config changes needed.

**Our deployment**: Transparent — no values impact.

### Overall risk assessment for our deployment 🟡
The changes are predominantly in the API/application layer, not the Helm chart schema. Our `values.yaml` is minimal (external PostgreSQL, HTTPRoute ingress, metrics annotations, existing secret) and none of the breaking changes affect these settings. The upgrade should be clean with no chart-side changes required.

**Recommendation**: Deploy and monitor. After upgrade, verify:
- Worker memory usage drops (check Prometheus/Grafana)
- SAML/OAuth2 providers continue to function (test a few logins)
- Application Dashboard renders correctly

## Impact on Current Setup

### Not affected
- **Default listen IP (`0.0.0.0` → `[::]`)**: Ingress is through Cilium Gateway (HTTPRoute), not direct port binding — no impact.
- **SAML auto-generated issuer URLs**: No SAML providers configured — no action needed.
- **SAML unified endpoints**: No SAML providers configured — no action needed.
- **Removed dependencies (17 packages)**: Transparent — no values/config impact.

### Beneficial
- **Rust worker entrypoint**: Approximately ~200MB RAM savings per worker container with fewer PostgreSQL connections — pure upside.

## Whats New (Highlights)

### Enterprise
- **Account Lockdown**: Panic button for compromised accounts — cut off access, revoke tokens, end sessions, leave audit trail
- **Conditional Access**: Fleet certificate and Google Chrome Device Trust connectors for device compliance

### Community
- **AKQL now open source**: Previously enterprise-only search query language is now free for all
- **Command Palette**: `Cmd+K` palette for quick UI navigation
- **WebAuthn Client Hints**: Support for WebAuthn Level 3 `hints` parameter (`security-key`, `client-device`, `hybrid`)
- **2FA attempt throttling**: Brute-force protection extended to email/SMS OTP devices
- **Import hashed passwords**: Bootstrap with pre-hashed Django passwords using `AUTHENTIK_BOOTSTRAP_PASSWORD_HASH`
- **OAuth2 configurable grant types**: Explicitly choose which grant types per provider
- **Improved UI/accessibility**: Native `<dialog>` modals, better screen reader support, reworked wizards, mobile improvements

## Whats Fixed (2026.5.1–2026.5.4)

| Version | Fixes |
|---|---|
| 2026.5.1 | Invitation emails ignoring selected template; paused schedules getting unpaused on startup; passkey autofill on identification stage; broker race condition causing repeated tasks; OAuth post logout redirect matching; missing tenant in setup migration; stale clipboard tokens & untranslated labels; SCIM discovery for users with no email |
| 2026.5.2 | Avatar URL encoding preservation; server-side message race condition; LDAP connection re-creation & optimization; OAuth error return via POST & request objects; WebAuthn `prevent_duplicate_devices` default (now disabled); pre_delete for TasksModel (OOM prevention) |
| 2026.5.3 | (Intermediate patch release) |
| 2026.5.4 | Various dependency bumps and security updates; pyo3 bump; crossbeam-epoch update; django-postgres-cache fixes; CI pipeline fixes |

## Upstream Release Notes

https://docs.goauthentik.io/releases/2026.5/
https://github.com/goauthentik/authentik/releases/tag/version/2026.5.4
