### PR TITLE
chore(deps): pyroscope 1.15.1 → 2.1.0

### DIFF
--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.15.1
+    version: 2.1.0
     releaseName: pyroscope
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | Target | Risk |
|---|---|---|---|
| pyroscope | 1.15.1 | 2.1.0 | high |

## Breaking Changes / Upgrade Notes

This is a **major version jump** (1.x → 2.x) with significant breaking changes in Pyroscope's storage architecture and the Helm chart.

### Helm chart 2.x breaking changes

> **Note for this deployment**: We run in **single-binary mode** (microservices not enabled), use **filesystem storage** via an existing PVC, and have no object storage configured.

#### Changed/removed Helm values

| Value | Status in 2.x | Our values.yaml |
|---|---|---|
| `pyroscope.persistence.enabled` | ✅ Still supported | `true` — no change needed |
| `pyroscope.persistence.existingClaim` | ✅ Still supported | `pyroscope-pvc` — no change needed |
| `pyroscope.persistence.shared` | ❌ **Removed** | Not used — no impact |
| `pyroscope.affinity` | ✅ Still supported | Node anti-affinity for `pi` — no change needed |
| `serviceMonitor.enabled` | ✅ Still supported | `true` — no change needed |
| `alloy.enabled` | ✅ Still supported (new default `true`; we set `false`) | `false` — no change needed |

#### New required/optional Helm values

| New value | Purpose | Default | Requires action? |
|---|---|---|---|
| `architecture.storage.v1` | Enable v1 storage layer (ingester, store-gateway, querier, compactor) | `false` | Not for us — we start with v2-only |
| `architecture.storage.v2` | Enable v2 storage layer (segment-writer, metastore, compaction-worker, query-backend) | `true` | Not for us — v2-only is correct |
| `architecture.storage.migration.ingesterWeight` | Fraction of write traffic to v1 (dual mode) | `1.0` | N/A (v1 disabled) |
| `architecture.storage.migration.segmentWriterWeight` | Fraction of write traffic to v2 (dual mode) | `1.0` | N/A (v2-only) |
| `architecture.storage.migration.queryBackendFrom` | Timestamp from which v2 read path serves traffic | `\"auto\"` | N/A (v2-only) |
| `pyroscope.persistence.metastore.subPath` | Sub-path for metastore data on the PVC | `.metastore` | Verify it works with existing PVC |

### Pyroscope application-level changes (via `extraArgs` / `structuredConfig`)

The following are **Pyroscope binary CLI flags**, not Helm values:

- `-enable-v1-write-path` / `-enable-v1-read-path` **removed** — replaced by `-architecture.storage` flag which accepts `v1`, `v1-v2-dual`, or `v2` (default: `v2`). The Helm chart manages this via `architecture.storage.{v1,v2}`.
- `-validation.disable-label-sanitization` **default changed** — now defaults to `true` (label sanitization disabled). UTF-8 label names with dots are accepted as-is. To restore v1 behavior, set `-validation.disable-label-sanitization=false` in `pyroscope.extraArgs`.
- **Default storage backend** is now `filesystem` (v2 writes segments to local disk / PVC), not S3.
- **v2 data paths** are under `./data/v2/` (handled automatically).

### Upgrade impact for this deployment

- **Our `values.yaml` needs no structural changes** — it doesn't use any of the removed values (`persistence.shared`, etc.) and the existing `existingClaim: pyroscope-pvc` is fully supported in 2.x.
- **Only `kustomization.yaml` is updated** — version bumped from `1.15.1` to `2.1.0`.
- **Storage behaviour change**: The 2.1.0 chart defaults to `architecture.storage.v2: true, v1: false` (v2-only filesystem storage on the PVC). This means:
  - Existing v1 profiling data on the PVC will **not be queryable** after upgrade (v1 read path is disabled).
  - New profiling data is written as segments under `./data/v2/.metastore/` on the same PVC.
  - If you need to preserve access to historical v1 data during a transition period, **do not merge this PR as-is** — instead, deploy with `architecture.storage.v1: true, v2: true` (dual mode) and follow the [Grafana v1→v2 migration guide](https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/).
- **Metastore needs a sub-path**: The 2.1.0 chart expects `pyroscope.persistence.metastore.subPath: .metastore` (which is the default). Our `values.yaml` doesn't set this, so the chart default applies — no action needed, but be aware the metastore creates its own directory on the PVC.

### Recommended pre-merge review

1. **Decide on migration strategy**: Direct cutover (v2-only, lose v1 data access) or dual-mode transition (keep v1 for reads while v2 ingests).
2. **Verify PVC ReadWriteMany**: The v2 metastore uses RAFT for consensus — in single-binary mode this isn't an issue, but if scaling to multiple replicas in the future, the filesystem backend would need a `ReadWriteMany` PVC.
3. **Test on a non-production cluster first** — this is a major version jump.

**Migration guide**: https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/

## Impact on Current Setup

This upgrade carries **one significant operational impact** and several non-issues:

- **v2 storage architecture default (v1 disabled)**: ⚠️ **AFFECTED** — The 2.1.0 chart defaults to `architecture.storage.v2: true, v1: false`, meaning the v1 read path is disabled. Existing v1 profiling data on the `pyroscope-pvc` PVC will become **unqueryable** after upgrade. New profiling data will be written as v2 segments under `./data/v2/` on the same PVC.

- **`architecture.storage` replaces old flags**: ✅ Not affected — our `values.yaml` doesn't use the removed `-enable-v1-write-path` / `-enable-v1-read-path` flags; the chart manages this via `architecture.storage.{v1,v2}`.

- **`persistence.shared` removed**: ✅ Not affected — this value was not used in our `values.yaml`.

- **Label sanitization disabled by default**: ✅ Not affected — if UTF-8 label names with dots cause issues, the v1 behavior can be restored by adding `-validation.disable-label-sanitization=false` to `pyroscope.extraArgs`.

- **Recommended action**: If historical v1 profiling data matters, do **not** merge this PR as-is. Instead, deploy with `architecture.storage.v1: true, v2: true` (dual mode) and follow the [v1→v2 migration guide](https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/) to migrate or retain access to existing data.

## Changelog

### pyroscope-2.1.0 (Jun 17, 2026)

#### Enhancements
- **distributor**: Add readiness checks
- **debuginfo**: Add list and delete APIs, including `profilecli` support
- **segment-writer**: Build dataset indexes in segments
- **metastore**: Add cache hit and miss metrics
- **distributor**: Add ingest parse duration histogram metrics
- **query-backend**: Add per-tenant, per-query bytes-fetched metrics
- **query-frontend**: Add estimation accuracy histogram metrics
- Add per-tenant limits for number of recording rules
- **Helm**: Default to v2 storage architecture
- **Helm**: Add `extraObjects` for deploying extra Kubernetes manifests
- **Monitoring**: Migrate dashboards to native histograms

#### Fixes
- Fix out-of-bounds panic in `clearAddresses`
- Fix nil matcher handling for recording rule upserts
- **store-gateway**: Validate tenant IDs
- Fix archive extraction issues (zip-slip/tar-slip cleanup)
- Fix label value cloning to avoid buffer reuse-after-free
- **query-backend**: Restore original start time for `RangeSeries` bucketing
- **read path**: Reject sub-millisecond `step` parameters
- Fix panic on unknown `QueryNode` types
- **store-gateway**: Restore ring info route from `/tenants` to `/ring`
- **speedscope**: Return error instead of panicking for unknown unit values
- **metastore**: Version shard cache reads
- **compaction-worker**: Correct `time_to_compaction_seconds` histogram buckets
- **Helm**: Add `apiVersion` and `kind` to `volumeClaimTemplates`

#### Security fixes
- **ui**: Update Vite to v8.0.16
- **ui**: Bump `tar`, `js-yaml`, and `@babel/core`
- **ui**: Bump `uuid` from 11.1.0
- **ui**: Patch CVE-2026-45149 and CVE-2026-46625
- Update `golang.org/x/net` to v0.53.0
- Update `golang.org/x/crypto` to v0.52.0
- Update `golang.org/x/image` to v0.41.0
- Update `github.com/prometheus/prometheus` to v0.311.3
- Update Go toolchain to v1.25.11

### pyroscope-2.0.0 (major - first v2 release)
- v2 storage architecture becomes the default
- Go module path bumped to `github.com/grafana/pyroscope/v2`
- Default write path flipped from `ingester` to `segment-writer`
- Default storage backend flipped to `filesystem`
- New `-architecture.storage` flag (v1, v1-v2-dual, v2), default `v1-v2-dual`
- Label sanitization disabled by default
- Helm chart restructured (see Breaking Changes above)

## Source

https://github.com/grafana/helm-charts/releases
