### PR TITLE
chore(deps): grafana-operator 5.21.4 → 5.24.0

### DIFF
--- a/apps/observability/grafana-operator/kustomization.yaml
+++ b/apps/observability/grafana-operator/kustomization.yaml
@@ -9,11 +9,11 @@ helmCharts:
   - name: grafana-operator
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 5.21.4
+    version: 5.24.0
     releaseName: grafana-operator
     valuesFile: values.yaml
 
 resources:
-  - https://github.com/grafana/grafana-operator/releases/download/v5.21.4/crds.yaml
+  - https://github.com/grafana/grafana-operator/releases/download/v5.24.0/crds.yaml
   - grafana.yaml
   - sealed-secret.yaml


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| grafana-operator | 5.21.4 | -> | 5.24.0 | yellow |

## Summary

Upgrade the Grafana Operator from v5.21.4 (Jan 2026) to v5.24.0 (Jun 2026), a jump of three minor versions spanning ~5 months of changes. No CRD migration steps are needed — CRDs are applied with `--server-side --force-conflicts` via the CRDs.yaml resource.

See the [cross-reference audit](#cross-reference-audit) below for per-change impact analysis against our manifests.

## Cross-Reference Audit

| Change | Version | Affects us? | Details |
|---|---|---|---|
| **GrafanaManifest CRD** (new) | 5.22.0 | ⚪ Available, unused | No GrafanaManifest resources exist in the repo. The CRD comes bundled in crds.yaml and is now available for future use (Playlists, ShortURLs, plugin resources, etc.). |
| **Cache strategy default: off → safe** | 5.22.0 | ✅ No impact | `values.yaml` does not set `enforceCacheLabels` — the default change is transparent. |
| **emptyDir-backed /tmp** | 5.22.1 | ✅ No impact | Operator-internal change for plugin downloads; no custom config needed. |
| **Pre-provisioned receivers deprecated** | 5.22.1 | ✅ Already migrated | We use `GrafanaContactPoint` CR in `contactpoints.yaml` — no `default-receiver` or `grafana-default-email` in use. |
| **Leader election RBAC fix** | 5.22.1 | ✅ No impact | Upstream RBAC fix, no config change needed. |
| **Grafana 13.0.1 default** | 5.23.0 | ✅ No impact | `grafana.yaml` uses `external.url: http://grafana:80` — we do not manage Grafana instance lifecycle. No `.spec.version` to update. |
| **Grafana >=13 gzip disabled** | 5.23.0 | ✅ No impact | Managed instance is already external. |
| **Generic API reconciler** | 5.24.0 | ⚪ Available, unused | New capability to manage previously unsupported Grafana API resources; not yet leveraged. |
| **OCI artifact source** | 5.24.0 | ⚪ Available, unused | Dashboards/library panels can now be fetched from OCI artifacts. |
| **Security fix** | 5.24.0 | ⚪ Important | Contains an important security fix (golang.org/x/crypto, golang.org/x/net updates). This alone warrants the upgrade. |

## Breaking Changes / Upgrade Notes

- **Skip intermediate releases**: The upstream recommends upgrading directly from 5.21.x to 5.24.0, skipping 5.22.0–5.22.2 due to CRD incompatibilities. This PR follows that guidance.
- **Cache strategy default changed** (5.22.0): The default fallback for the cache strategy changed from `off` to `safe`. If you have not explicitly set `enforceCacheLabels` to null (we haven't — see `values.yaml`), this does not affect you.
- **Grafana 13.0.1 default** (5.23.0): The default Grafana version bumped to 13.0.1. Existing instances are not automatically updated — modify `.spec.version` to upgrade. **Not applicable** to us — our `grafana.yaml` uses an external Grafana instance.
- **Grafana >=13 gzip disabled** (5.23.0): Gzip compression disabled by default for Grafana >= 13. **Not applicable** to us.
- **emptyDir for /tmp** (5.22.1): Plugin downloads now use an emptyDir-backed `/tmp` volume instead of `TMPDIR` env (which Grafana >= 12.4.0 ignores). Operator-internal change, no user config impact.
- **Pre-provisioned receivers deprecated** (5.22.1): `default-receiver` and `grafana-default-email` are deprecated starting Grafana 12.4.0+. **Already migrated** — we use `GrafanaContactPoint` CR.
- **No known breaking changes from 5.x overall** — updates should be trivial. The Grafana Operator maintains backward compatibility within the v5 line.

## Impact on Current Setup

This upgrade has **no operational impact** on the current deployment. All identified changes are either transparent to us or deliberately avoided:

- **Cache strategy default (off → safe)**: Not affected — we use an external Grafana instance, so the operator's internal cache is not involved.
- **Grafana version bump (13.0.1 default)**: Not affected — our Grafana instance is managed externally via CRD, not by the operator's lifecycle.
- **emptyDir-backed /tmp for plugin installs**: Not affected — no Grafana plugins are configured in the deployment.
- **New GrafanaManifest CRD**: Not affected — no GrafanaManifest resources exist in the repository. The CRD is available for future use but unused today.
- **Security fixes** (golang.org/x/crypto, golang.org/x/net): **Beneficial** — these are patched vulnerabilities that reduce the operator's attack surface with no side effects.

The only file changed is the Helm chart version in `kustomization.yaml`. ArgoCD will detect the version change and perform a rolling update of the operator pod. Existing Grafana resources (dashboards, datasources, alert rules, contact points, folders) are unaffected — CRD schemas are backward-compatible within the v5 line.

## Changelog

### v5.24.0 (Jun 9, 2026)

**Features:**
- Add Generic API reconciler for managing previously unsupported Grafana resources
- Add OCI artifact source for dashboard and library panel content

**Fixes:**
- Fix AlertRuleGroup query model normalization before drift compare
- Fix jsonnet imports using os.Root
- **Important security fix** — update ASAP

**Security:**
- Update `golang.org/x/crypto` to v0.52.0
- Update `golang.org/x/net` to v0.55.0

### v5.23.0 (May 21, 2026)

**Features:**
- Update Grafana Deployment when referenced Secret/ConfigMap contents change
- Make leader election optional (OLM)
- Feature flag API
- Allow setting `ipFamilyPolicy` in helm chart
- Disable gzip compression in Grafana >= 13

**Fixes:**
- NamespaceScope RBAC avoids ClusterRole
- Make `tenantNamespace` optional
- Do not propagate applyset labels to child resources
- Handle corrupted cache
- Fix matchExpressions for instances with no labels
- Limit GVR resolving to correct kind

### v5.22.2 (Mar 17, 2026)

**Fixes:**
- Escape reserved identifiers in CEL rules for k8s < 1.32 compatibility
- Fix incomplete CEL for namespace immutability check in GrafanaManifest

### v5.22.1 (Mar 13, 2026)

**Fixes:**
- Fix LeaderElection events generation (RBAC)
- Fix `--zap-devel=true` not enabling debug logs
- Fix tmp dir permissions for plugin installation in Grafana 12.4.0+
- Remove extra rolebinding with `namespaceScope=true` without `watchNamespaces`
- Bump default Grafana to 12.4.0

### v5.22.0 (Feb 24, 2026)

**Features:**
- **New CRD: `GrafanaManifest`** — manage previously unsupported Grafana API resources (Playlists, ShortURLs, plugin resources)
- Dynamic resource patching with jq for GrafanaManifest
- AlertRuleGroup: `targetDatasourceUid` for recording rules, `active_time_intervals` in notificationSettings
- GrafanaServiceAccount: `.spec.name` made optional (defaults to `metadata.name`)

**Changes:**
- Default cache strategy changed from `off` to `safe`

## Files Changed

Only one file modified:

| File | Changes |
|---|---|
| `apps/observability/grafana-operator/kustomization.yaml` | Helm chart version 5.21.4 → 5.24.0, CRDs URL v5.21.4 → v5.24.0 |

## Verification

- `kubectl kustomize apps/observability/grafana-operator --enable-helm` renders cleanly
- CRDs are applied server-side with force-conflicts
- No schema changes needed for existing `Grafana`, `GrafanaDashboard`, `GrafanaContactPoint`, `GrafanaFolder`, `GrafanaDatasource`, or `GrafanaAlertRuleGroup` resources

## Source

https://github.com/grafana/grafana-operator/releases/tag/v5.24.0
