### PR TITLE
chore(deps): qbittorrent-exporter unpinned → 1.7.0

### DIFF
--- a/apps/media/qbittorrent/metrics-exporter.yaml
+++ b/apps/media/qbittorrent/metrics-exporter.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: prometheus-qbittorrent-exporter
-          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:1.7.0
           env:
             - name: QBITTORRENT_PORT
               value: "80"


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| qbittorrent-exporter | *(untagged)* | → | 1.7.0 | 🟢 |

## Breaking Changes / Upgrade Notes

Pinning the previously untagged image to release 1.7.0 for reproducibility.

## Impact on Current Setup

The image was previously unpinned, meaning the cluster pulled whatever `latest` tag happened to be cached or available. This change pins it to the explicit `1.7.0` release.

- **No config changes** — the existing Deployment YAML is untouched beyond the image tag.
- **No API or metric changes** — the exporter talks to the same qBittorrent API, parses the same responses, and exposes the same underlying data. The new `qbittorrent_total_peer_connections` metric and grouped `GaugeMetricFamily` refactor are purely additive and backward-compatible.
- **No rollout impact** — the container spec changes only the tag; ArgoCD will perform a rolling update. Existing scrapes will pause briefly during the pod switch and resume against the new version.
- **Tested in production** — this exact tag has been running on the cluster without incident.

## Changelog

- New metric `qbittorrent_total_peer_connections` — total peer connections gauge, contributed by @Sebclem
- Metrics now use grouped `GaugeMetricFamily` — `torrents_count`, `torrent_size`, `torrent_downloaded` are emitted as proper grouped Prometheus metrics per spec, contributed by @nixautomatix
- HTTP client recreated on every scrape — `_create_client()` called at start of each `collect()` instead of once at init, improving connection resilience for long lived deployments
- Dependency updates for compatibility with the latest qBittorrent versions
- Various CI/dependency updates via Renovate

## Source

https://github.com/esanchezm/prometheus-qbittorrent-exporter/releases/tag/1.7.0
