### PR TITLE
chore(deps): kube-prometheus-stack 78.1.0 → 87.15.1

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 78.1.0
+    version: 87.15.1
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 78.1.0 | → | 87.15.1 | 🔴 |

## Breaking Changes / Upgrade Notes

This crosses several chart major versions (78.x → 87.x) spanning Prometheus Operator v0.86.0 → v0.92.1. Key upstream breaking changes encountered along the way:

### 78.x → 79.x
- Grafana admin password no longer defaults to `prom-operator`; it is now randomly generated. **Not applicable** — Grafana is disabled in our config (`grafana.enabled: false`).

### 79.x → 80.x (Prometheus Operator v0.87.0)
### 80.x → 81.x (Prometheus Operator v0.88.0)
### 81.x → 82.x (Prometheus Operator v0.89.0)
### 82.x → 83.x (Prometheus Operator v0.90.1)
### 83.x → 84.x (Grafana v13.0.0)
- Not applicable — Grafana is disabled.

### 84.x → 85.x
- Switched to **distroless** images by default for Prometheus and prometheus-node-exporter. **Not applicable** — nodeExporter is disabled.

### 85.x → 86.x (Prometheus Operator v0.91.0)
### 86.x → 87.x (Prometheus Operator v0.92.0)

**CRD Updates Required:** CRDs must be updated before applying this upgrade (Prometheus Operator v0.86.0 → v0.92.1):

```console
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
```

## Impact on Current Setup

All keys in `kube-prometheus-stack-values.yaml` were verified against the 87.15.1 chart defaults. **No deprecated, renamed, or removed keys were found.** The values file requires no changes.

Current configuration (apps/observability/prometheus/kube-prometheus-stack-values.yaml):
- Alertmanager, Grafana, nodeExporter, kubeStateMetrics: **disabled**
- Default rules and Kubernetes service monitors: **disabled**
- Prometheus: 120d retention, remote write receiver enabled, OTLP receiver enabled, admin API enabled
- Storage: PVC template with NFS-based static PV binding
- Network: Gateway API HTTPRoute via `cilium-shared-gateway` on `prometheus.g2net.xyz`
- Affinity: anti-affinity for the `pi` node

**Risk Assessment:** 🔴 High — this is a major version bump spanning 9 chart major versions with multiple Prometheus Operator version jumps (v0.86.0 → v0.92.1). CRDs must be updated prior to upgrade. No values changes needed, but thorough post-upgrade validation of Prometheus, rules, and alerting is recommended.

## Changelog

- [[kube-prometheus-stack] Update Helm release kube-state-metrics to v7.8.1 by @renovate[bot] in #7102](https://github.com/prometheus-community/helm-charts/pull/7102)
- **Full Changelog**: [`prometheus-conntrack-stats-exporter-0.5.38...kube-prometheus-stack-87.15.1`](https://github.com/prometheus-community/helm-charts/compare/prometheus-conntrack-stats-exporter-0.5.38...kube-prometheus-stack-87.15.1)

## Source

https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.15.1