### PR TITLE
chore(deps): alpine/sqlite 3.51.2 → 3.53.2

### DIFF
--- a/apps/freshrss/pre-backup-pod.yaml
+++ b/apps/freshrss/pre-backup-pod.yaml
@@ -11,7 +11,7 @@ spec:
         runAsUser: 0
       containers:
         - name: freshrss-sqlite-dump
-          image: alpine/sqlite:3.51.2
+          image: alpine/sqlite:3.53.2
           command:
             - 'sleep'
             - 'infinity'

--- a/apps/observability/grafana/pre-backup-pod.yaml
+++ b/apps/observability/grafana/pre-backup-pod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: grafana-sqlite-dump
-          image: alpine/sqlite:3.51.2
+          image: alpine/sqlite:3.53.2
           command:
             - 'sleep'
             - 'infinity'


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| alpine/sqlite | 3.51.2 | → | 3.53.2 | 🟢 |

## Breaking Changes / Upgrade Notes

Patch version bump for the sqlite library in Alpine Linux — no breaking changes.

## Changelog

3.51.2 → 3.53.2: Sqlite upstream bug fixes and stability improvements.

## Impact on Current Setup

Patch version bump for sqlite in Alpine Linux. No config changes needed.

## Source

https://hub.docker.com/r/alpine/sqlite