### PR TITLE
chore(deps): k8up 4.8.6 → 4.9.0

### DIFF
--- a/apps/backup/kustomization.yaml
+++ b/apps/backup/kustomization.yaml
@@ -8,10 +8,10 @@ helmCharts:
   - name: k8up
     repo: https://k8up-io.github.io/k8up
     namespace: backup
-    version: 4.8.6
+    version: 4.9.0
     releaseName: k8up
     valuesFile: values.yaml
 
 resources:
   - sealed-secret.yaml
-  - https://github.com/k8up-io/k8up/releases/download/k8up-4.8.6/k8up-crd.yaml
+  - https://github.com/k8up-io/k8up/releases/download/k8up-4.9.0/k8up-crd.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| k8up | 4.8.6 | → | 4.9.0 | 🟡 |

## Config cross-reference

All changes were checked against the repo's actual configuration at `apps/backup/values.yaml` and `apps/**/pre-backup-pod.yaml`.

### ✅ SPDY → WebSockets streaming (`#1183`)

**What changed:** k8up now uses WebSockets instead of SPDY for `pod exec` streaming (used when running `backupCommand` inside `PreBackupPod` containers). This is the default in Kubernetes 1.32+; older clusters may have compatibility issues.

**Impact on this repo:** The repo has **8 `PreBackupPod` resources** (wallabag, freshrss, sonarr, radarr, prowlarr, jellyfin, linkding, grafana) that rely on k8up exec'ing into a sidecar container to run e.g. `sqlite3` dumps. If the cluster's kubelet or container runtime doesn't support WebSockets-based exec, backups for these apps could fail.

**Mitigation (no config change needed yet):** The fallback env var `INSECURE_ALLOW_PODEXEC_SPDY_FALLBACK` is **not set** in `values.yaml`. If backups break after upgrade, add:

```yaml
k8up:
  envVars:
    - name: INSECURE_ALLOW_PODEXEC_SPDY_FALLBACK
      value: "true"
```

### ✅ nodeSelector/tolerations/affinity on cleanup hook (`#1175`)

**What changed:** The Helm chart now supports `k8up.cleanup.nodeSelector`, `k8up.cleanup.tolerations`, and `k8up.cleanup.affinity` for the cleanup (pre-upgrade/pre-delete) hook Job.

**Impact on this repo:** **None.** The repo does not set any cleanup hook customizations. These are opt-in chart values, so the upgrade will use defaults (no nodeSelector, tolerations, or affinity on the cleanup hook). No config change needed.

### ✅ `globalResources` env var name fix (`#1168`)

**What changed:** Fixed incorrect env var names in the Helm chart related to `globalResources` (the chart was using wrong keys to pass resource limits/requests to the k8up operator pod).

**Impact on this repo:** **None.** The repo does not set `globalResources` (the `values.yaml` is minimal — only `timezone`, `skipWithoutAnnotation`, and metrics annotations). No config change needed.

### 📌 Chart version bump only

k8up-4.9.0 is a **Helm chart-only release** — the bundled k8up operator version may change system requirements. Consult [supported Kubernetes versions](https://docs.k8up.io/k8up/2.15/explanations/system-requirements.html#_supported_kubernetes_versions) to ensure cluster compatibility.

## Upgrade plan

| Step | Action | Details |
|------|--------|---------|
| 1 | Update Helm chart version | `kustomization.yaml`: `version: 4.8.6` → `4.9.0` |
| 2 | Update CRD URL | `kustomization.yaml`: CRD URL `4.8.6` → `4.9.0` |
| 3 | Deploy | `kubectl apply -k apps/backup` (or ArgoCD auto-sync) |
| 4 | Verify app-aware backups | Check `PreBackupPod` execution for the 8 apps using them; if failures occur, add the SPDY fallback env var |

## Impact on Current Setup

### 🟡 SPDY → WebSockets streaming (#1183)
**8 PreBackupPod resources** (wallabag, freshrss, sonarr, radarr, prowlarr, jellyfin, linkding, grafana) use k8up exec for backup commands. The switch from SPDY to WebSockets may cause failures on clusters without WebSocket exec support. The env var `INSECURE_ALLOW_PODEXEC_SPDY_FALLBACK` is **not set** — this is an optional post-upgrade mitigation if backups break.

### 🟢 nodeSelector/tolerations/affinity on cleanup hook (#1175)
**No impact.** The repo does not configure cleanup hook customizations; defaults apply. Opt-in only.

### 🟢 globalResources env var fix (#1168)
**No impact.** `globalResources` is not used in `values.yaml`. No config change needed.

### Summary
No breaking changes to existing configuration. One moderate-risk change (SPDY → WebSockets) requires post-upgrade verification of the 8 PreBackupPod backups. Two other changes are purely additive and do not affect current setup.

## Changelog

### k8up-4.8.7 (Helm chart changes only)

**Features**
- helm chart: allow setting resources on the cleanup job/hook ([#1091](https://github.com/k8up-io/k8up/pull/1091))
- Bump Chart version ([#1148](https://github.com/k8up-io/k8up/pull/1148))

### k8up-4.9.0 (Helm chart changes only)

**Features**
- Add nodeSelector, tolerations, and affinity to cleanup hook ([#1175](https://github.com/k8up-io/k8up/pull/1175))

**Fixes**
- Fix globalResources env var names in Helm chart ([#1168](https://github.com/k8up-io/k8up/pull/1168))
- Use websockets instead of SPDY for streaming ([#1183](https://github.com/k8up-io/k8up/pull/1183))

**Dependency Updates**
- Bump chart version ([#1185](https://github.com/k8up-io/k8up/pull/1185))

## Source

https://github.com/k8up-io/k8up/releases/tag/k8up-4.9.0