### PR TITLE
chore(deps): ingress-nginx 4.13.1 → 4.15.1

### DIFF
--- a/apps/ingress-nginx/kustomization.yaml
+++ b/apps/ingress-nginx/kustomization.yaml
@@ -6,6 +6,6 @@ helmCharts:
   - name: ingress-nginx
     repo: https://kubernetes.github.io/ingress-nginx
     namespace: ingress-nginx
-    version: 4.13.1
+    version: 4.15.1
     releaseName: ingress-nginx
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| ingress-nginx | 4.13.1 | -> | 4.15.1 | :yellow_circle: |

## Breaking Changes / Upgrade Notes

- **Project Retirement**: ingress-nginx was archived on Mar 24, 2026. This is the final release line. Plan migration to an alternative ingress controller (e.g., nginxinc ingress or gateway-api).
- **Template quoting changes**: `proxy_pass`, `location`, and `server_name` directives are now properly quoted. Custom configurations relying on unquoted template overrides may need updates.
- **SSL Proxy**: PROXY protocol v2 support added for SSL passthrough.
- **Auth method regex**: Stricter validation -- `^` and `$` anchors added to auth method regex; custom auth methods may be affected.
- **Stronger ciphers default**: Config now uses stronger ciphers first by default.
- **Helm v4.x**: CI updated from Helm v3 to v4 (chart templating should be backward compatible).
- **Alpine bumped** to v3.23.3, **Go bumped** to v1.26.1.

## Changelog

### helm-chart-4.15.1 (controller-v1.15.1)
- Update Ingress-Nginx version controller-v1.15.1
- Template: Remove path from comment
- CI: Update Kubernetes to v1.35.3
- CI: Update Helm to v4.1.3
- Go: Update dependencies
- Various dependency bumps

### helm-chart-4.15.0 (controller-v1.15.0)
- Update Ingress-Nginx version controller-v1.15.0
- Template: Quote `proxy_pass`, `location`, and `server_name` directives
- Annotations: Consider aliases in risk evaluation
- Annotations: Use dedicated regex for `proxy-cookie-domain`
- Annotations: Add `^` and `$` to auth method regex
- Controller: Enable SSL Passthrough when requested on before HTTP-only hosts
- Controller: Use 4KiB buffers for PROXY protocol parsing in TLS passthrough
- Controller: Fix sync for host clock jumps to future
- Controller: Verify UIDs
- Admission Controller: Remove obsolete error log, Use 9 MB limit
- Template: Bypass custom error pages when handling auth URL requests
- Template: Use `RawURLEncoding` instead of `URLEncoding` with padding removal
- Config: Use stronger ciphers first
- Lua: Fix type mismatch
- Util: Fix panic for empty `cpu.max` file
- Go: Bump to v1.26.1
- CI: Update Kubernetes to v1.35.2, KIND to v1.35.1
- CI: Update Helm to v4.1.1
- Images: Bump Alpine to v3.23.3
- Images: Bump NGINX to v2.2.8
- Tests: Bump Ginkgo to v2.28.1, Test Runner to v2.2.8
- Docs: Add retirement notice
- Various dependency bumps

### helm-chart-4.14.x series (controller-v1.14.x)
The 4.14.x series introduced controller-v1.14.0 which included:
- SSL Proxy: PROXY protocol v2 support
- Status: Multiple Node IP addresses support
- Chart: Make extra init containers templatable, add resize policy, add scrapeTimeout
- Controller: Fix `limit_req_zone` sorting
- Store: Handle panics in service deletion handler
- Go: Bump to v1.25.x
- CI: Update Kubernetes to v1.34.x, Helm to v3.19.x
- Chart: Bump Kube Webhook CertGen
- Various dependency bumps and fixes

### helm-chart-4.13.x series (controller-v1.13.x)
The 4.13.x releases after 4.13.1 consisted of patch updates and dependency bumps within the v1.13 controller line, culminating in controller-v1.13.9.

## Source

https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.15.1

## Impact on Current Setup

This section cross-references each breaking change against the current deployment configuration (`apps/ingress-nginx/values.yaml`).

**Current values.yaml:**
```yaml
controller:
  replicaCount: 2
```

The deployment is minimal -- no custom templates, no ConfigMap overrides, no annotation-based customizations, and no patches. Each breaking change is assessed below.

| Breaking Change | Affected? | Details |
|---|---|---|
| **Template quoting changes** (single->double quotes in `proxy_pass`, `location`, `server_name`) | :x: No | No custom template overrides, snippets, or annotation-based directives are defined in values.yaml. Default templates handle quoting transparently. |
| **Auth URL regex hardening** (`^`/`$` anchors in auth method regex) | :x: No | No auth-related configuration present (`controller.config.auth-*`, custom auth annotations, or `global-auth-*` settings). |
| **Stronger ciphers default** (TLS_AES_128_GCM_SHA256 removed, stronger ciphers reordered first) | :warning: Low | `ssl-ciphers` is not overridden, so the new default cipher list applies automatically. Security improvement with no config changes needed. Only affects very old clients that specifically require TLS_AES_128_GCM_SHA256. |
| **Helm v4 compatibility** | :x: No | Local Helm is v3.17.2; ArgoCD's Kustomize controller uses Helm v3. The chart's v4 CI updates have no effect on our rendering pipeline. |
| **Project archived** (retirement notice, Mar 2026) | :warning: Long-term | No immediate operational impact, but this is the final release line. A migration to an alternative ingress controller (nginxinc ingress, gateway-api, or similar) should be planned. |

**Summary:** The upgrade from 4.13.1 -> 4.15.1 is low risk for this deployment. All breaking changes are either inapplicable (no custom templates/auth config), automatically resolved (new cipher defaults applied via chart defaults), or non-impacting (Helm v4 CI changes). The only action item is to begin planning a migration away from the archived ingress-nginx project. :green_circle: