### PR TITLE
chore(deps): cilium 1.18.2 → 1.19.5

### DIFF
--- a/apps/tailscale/kustomization.yaml
+++ b/apps/tailscale/kustomization.yaml
@@ -12,6 +12,6 @@ helmCharts:
   - name: tailscale-operator
     repo: https://pkgs.tailscale.com/helmcharts
     namespace: tailscale
-    version: 1.88.2
+    version: 1.98.4
     releaseName: tailscale-operator
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cilium | 1.18.2 | → | 1.19.5 | 🟡 |

## Breaking Changes / Upgrade Notes

See https://docs.cilium.io/en/v1.19/operations/upgrade/ for full details.

### Action Required

**Network Policy:**
- DNS patterns with `**` now match multiple subdomains (previously treated same as `*`). Check patterns starting with `**.`.
- `FromRequires` and `ToRequires` fields now enforced empty — policies using these must be updated before upgrade.
- Kafka Network Policy support is deprecated (will be removed in 1.20).
- `mesh-auth-enabled` (Helm `authentication.enabled`) is now **disabled by default** — enable explicitly if using Mutual Authentication.

**Cluster Mesh:**
- `policy-default-local-cluster` defaults to `true` — network policy selectors only select endpoints from the local cluster by default. Set to `false` to retain previous behavior, or update policies with explicit cluster selectors.
- `clustermesh.apiserver.tls.authMode` defaults to `migration` — create `clustermesh-remote-users` ConfigMap or set `authMode=legacy` if using specific configurations.

**Custom Resource Versions:**
- `CiliumLoadBalancerIPPool`: change `apiVersion: cilium.io/v2alpha1` → `cilium.io/v2`
- `CiliumBGPPeeringPolicy` (BGPv1) CRD **removed** — migrate to `cilium.io/v2` CRDs (`CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`, `CiliumBGPNodeConfigOverride`) before upgrading.

**Removed Flags:**
- `--enable-node-port`, `--enable-host-port`, `--enable-external-ips` removed (use `--kube-proxy-replacement=true`)
- `--enable-ipv4-egress-gateway` removed (use `--enable-egress-gateway=true`)
- `--l2-pod-announcements-interface` removed (use `--l2-pod-announcements-interface-pattern`)
- PCAP recorder, session-affinity, internal-traffic-policy, svc-source-range-check flags removed
- `--enable-custom-calls`, `--bpf-lb-proto-diff` removed
- `--egress-multi-home-ip-rule-compat` removed

### Informational

- BPF Host-Routing with IPsec now requires a kernel bugfix (CVE-2025-37959). Ensure kernel is up to date, or set `--enable-host-legacy-routing=true`.
- `bpf.tproxy=true` is incompatible with netkit datapath mode. Use veth or disable `bpf.tproxy`.
- Hubble field mask API stabilized: `--experimental-field-mask` → `--field-mask` (enabled by default).
- `--unmanaged-pod-watcher-interval` flag type changed from `int` (seconds) to `time.Duration` (e.g., `15` → `15s`).
- Certificate generation with CronJob method changed — Job resources no longer use Helm post-install hooks.
- MCS-API CRDs are now installed and managed by Cilium by default (opt out with `clustermesh.mcsapi.installCRDs=false`).

## Impact on Current Setup

This section evaluates each breaking/notable change against this deployment's actual configuration at `apps/cilium/values.yaml` and companion resources. No action items were identified.

### Per-Item Analysis

| Change | Verdict | Details |
|---|---|---|
| `FromRequires`/`ToRequires` removal | :white_check_mark: Not affected | No `CiliumNetworkPolicy` resources exist anywhere in this repo. |
| DNS wildcard matching (`.foo.com` requires leading dot) | :white_check_mark: Not affected | No DNS-based policies are in use. |
| `authentication.enabled` now disabled by default | :white_check_mark: Not affected | No CiliumNetworkPolicies rely on mutual authentication; omitted from `values.yaml` with no impact on current behavior. |
| Cluster Mesh: `policy-default-local-cluster` default `true` | :white_check_mark: Not affected | Cluster Mesh is not configured (no `clustermesh` section in `values.yaml`). |
| BGPv1 CRD removal (`CiliumBGPPeeringPolicy`) | :white_check_mark: Not affected | No BGP configuration present. |
| IPsec kernel requirement (CVE-2025-37959) | :white_check_mark: Not affected | IPsec/encryption not enabled (`encryption` and `ipsec` absent from `values.yaml`). |
| CRD migration: `CiliumLoadBalancerIPPool` `v2alpha1` → `v2` | :white_check_mark: Not affected | `apps/cilium/ip-pool.yaml` already uses `cilium.io/v2` — no migration needed. |
| Removed CLI flags (`--enable-node-port`, `--enable-host-port`, `--enable-external-ips`, etc.) | :white_check_mark: Not affected | Helm value `kubeProxyReplacement: true` is already set, which is the recommended replacement. |
| Ingress/Gateway API | :white_check_mark: Not affected | `ingressController` and `gatewayAPI` configs remain valid in 1.19. |
| L2 announcement | :white_check_mark: Not affected | `apps/cilium/announcement-policy.yaml` uses `cilium.io/v2alpha1` (stable, not being removed). |
| Hubble UI connectivity changes | :information_source: Informational | Hubble UI and Relay are enabled. Verify Hubble UI loads correctly after upgrade. |

### Summary

**No action required.** All breaking changes either do not apply to this deployment (no CiliumNetworkPolicies, no Cluster Mesh, no BGP, no IPsec) or are already accounted for (CiliumLoadBalancerIPPool already on `v2`, `kubeProxyReplacement` already enabled). Post-upgrade verification of Hubble UI is recommended.

## Changelog

### Releases between 1.18.2 and 1.19.5

**1.18.x patch releases**: 1.18.3, 1.18.4, 1.18.5, 1.18.6, 1.18.7, 1.18.8, 1.18.9, 1.18.10, 1.18.11

**1.19.x releases**: 1.19.0, 1.19.1, 1.19.2, 1.19.3, 1.19.4, 1.19.5

### 1.19.5 (Jun 16, 2026) — Latest patch

**Minor Changes:**
- Extend the information reported by the troubleshoot kvstore and clustermesh commands
- helm: Remove loadBalancer.standalone option
- wireguard:mtu: fix mtu calculation with potential padding

**Bugfixes:**
- Fix CiliumNetworkPolicy with `fromNodes`/`toNodes` and `policy-default-local-cluster` enabled (always add cluster label to node when `nodeSelectorLabels` is enabled)
- azure: Fix public IP reassignment failure loop on operator restart
- bgp: Dont provide default_gateway reconciler when disabled; reduce amount of soft peer resets by service reconciliation
- bpf: fix host proxy packet routing to pods
- Fix weighted backend traffic splitting for TLSRoute passthrough listeners in Gateway API
- Fix NamespaceSelector corruption in CiliumEgressGatewayPolicy
- Fix clustermesh-apiserver endpoint deletion under high pod churn
- Fix BGP PeerConfig status cleanup timeout
- Fix connectivity disruption when ClusterIP/LoadBalancer VIPs overlap with node-local IPs
- Fix TLS passthrough routes failing silently with mixed Gateway listeners
- Fix wildcard namespace bypass for selectorless ipBlock rules
- Fix Gateway API controller panic on malformed GatewayClass/parametersRef
- Fix EndpointSlice ready condition in gateway-api
- Fix policymap pressure incorrectly reported as 0
- Fix unsolicited IPv6 L2 announcements (RFC 4861 compliance)
- Fix reused endpoint ID BPF state directory race
- Fix nil pointer dereference panic (uninitialized logger)
- Various Gateway API, Hubble, and IPAM fixes
- iptables: match wireguard packets by proto+port instead of packet mark
- Internal representation of load-balancing backends refactored for scale (thousands of services sharing a backend)

## Source

https://github.com/cilium/cilium/releases/tag/v1.19.5

## Upgrade Reference

https://docs.cilium.io/en/stable/operations/upgrade/
