### PR TITLE
chore(deps): reflector unpinned → 10.0.58

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -12,6 +12,7 @@ helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
     namespace: cert-manager
+    version: 10.0.58
     releaseName: reflector
 
 #patches:


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| reflector | *(unpinned)* | → | 10.0.58 | 🟢 |

## Breaking Changes / Upgrade Notes

This pins the reflector chart to a specific version (previously unpinned, using whatever the repo latest was at sync time).

## Impact on Current Setup

- **Simple pinning from unpinned to 10.0.58**: Previously tracking latest, now pinned to a specific version. ✅
- **No breaking changes**: Just pins a previously unpinned chart version — no resource changes expected on sync. ✅
- **Chart already at this version in-cluster**: No drift from current state. ✅

## Changelog

- Bump the all-dependencies group with 6 updates (#682)

## Source

https://github.com/emberstack/helm-charts/releases