### PR TITLE
fix: route cilium-operator API traffic through k8s service VIP

### DIFF
--- a/apps/cilium/values.yaml
+++ b/apps/cilium/values.yaml
@@ -1,5 +1,5 @@
 ---
-k8sServiceHost: 192.168.0.210
+k8sServiceHost: 10.43.0.1
 k8sServicePort: 6443
 
 l2announcements:


### PR DESCRIPTION
**Problem:** `k8sServiceHost: 192.168.0.210` pins all cilium-operator replicas to pi's API server. When pi's etcd has transient failures, the leader lease `cilium-operator-resource-lock` times out and both operator replicas crash (185 + 140 restarts), cascading into controller reconciliation issues (DaemonSetMisScheduled, etc.).

**Fix:** Route through the kubernetes service VIP `10.43.0.1` so API traffic load-balances across all 3 control-plane nodes.