### PR TITLE
revert: use pi node IP for k8sServiceHost

### DIFF
--- a/apps/cilium/values.yaml
+++ b/apps/cilium/values.yaml
@@ -1,5 +1,5 @@
 ---
-k8sServiceHost: 10.43.0.1
+k8sServiceHost: 192.168.0.210
 k8sServicePort: 6443
 
 l2announcements:


### PR DESCRIPTION
**What happened:** Changing k8sServiceHost to the kubernetes service VIP (10.43.0.1) caused a bootstrap deadlock with Cilium's kube-proxy replacement. Both agents and operators need API access via the VIP to start — but the VIP only works with Cilium running. Direct node IP bypasses this.

**This revert:** Changes back to pi's direct IP (192.168.0.210).

**Next step:** Pi's etcd has intermittent failures causing operator leader election timeouts. The VIP approach won't work until Cilium supports a bootstrap-safe API server path.