### PR TITLE
fix: remove nonexistent :1.7.0 tag from prometheus-qbittorrent-exporter

### DIFF
--- a/apps/media/qbittorrent/metrics-exporter.yaml
+++ b/apps/media/qbittorrent/metrics-exporter.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: prometheus-qbittorrent-exporter
-          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:1.7.0
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter
           env:
             - name: QBITTORRENT_PORT
               value: "80"


### PR DESCRIPTION
The image tag `:1.7.0` doesn't exist on GHCR — pull fails with `not found`. This causes:
- KubeDeploymentRolloutStuck (ProgressDeadlineExceeded)
- KubePodNotReady (ImagePullBackOff)
- KubeContainerWaiting (ImagePullBackOff)

Fixes by removing the tag (defaults to `:latest`, which exists). ArgoCD will auto-sync after merge.