### PR TITLE
fix: pin prometheus-qbittorrent-exporter to :v1.7.0 instead of :latest

### DIFF
--- a/apps/media/qbittorrent/metrics-exporter.yaml
+++ b/apps/media/qbittorrent/metrics-exporter.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: prometheus-qbittorrent-exporter
-          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter
+          image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.7.0
           env:
             - name: QBITTORRENT_PORT
               value: "80"


### PR DESCRIPTION
PR #318 removed the non-existent `:1.7.0` tag, defaulting to `:latest`. This PR explicitly pins to `:v1.7.0` (the actual tag on GHCR) for deterministic and predictable behavior — `:latest` is mutable and can change with upstream releases.

**Change:**
```diff
- image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter
+ image: ghcr.io/esanchezm/prometheus-qbittorrent-exporter:v1.7.0
```

**Verification:** Tag `v1.7.0` confirmed present on GHCR tag list.