### PR TITLE
temporarily disable itarmy deployment

### DIFF
--- a/argocd/apps/itarmy.yaml
+++ b/argocd/apps/itarmy.yaml
@@ -1,24 +1,24 @@
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: itarmy
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
-spec:
-  project: default
-  destination:
-    namespace: itarmy
-    server: https://kubernetes.default.svc
-  source:
-    path: apps/itarmy
-    repoURL: https://github.com/gedulis12/homelab
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      allowEmpty: true
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
+# ---
+# apiVersion: argoproj.io/v1alpha1
+# kind: Application
+# metadata:
+#   name: itarmy
+#   namespace: argocd
+#   finalizers:
+#     - resources-finalizer.argocd.argoproj.io
+# spec:
+#   project: default
+#   destination:
+#     namespace: itarmy
+#     server: https://kubernetes.default.svc
+#   source:
+#     path: apps/itarmy
+#     repoURL: https://github.com/gedulis12/homelab
+#     targetRevision: HEAD
+#   syncPolicy:
+#     automated:
+#       allowEmpty: true
+#       prune: true
+#       selfHeal: true
+#     syncOptions:
+#       - CreateNamespace=true


### PR DESCRIPTION
Temporarily disables the IT Army kit by commenting out its ArgoCD Application definition in `argocd/apps/itarmy.yaml` — ArgoCD's directory source will skip the commented-out file.

**To re-enable:** uncomment the file and merge.

**Effect:** ArgoCD will prune the itarmy DaemonSet and namespace resources on next sync.