### PR TITLE
chore(deps): reflector 10.0.58 → 10.0.59

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -12,7 +12,7 @@ helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
     namespace: cert-manager
-    version: 10.0.58
+    version: 10.0.59
     releaseName: reflector
 
 #patches:


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| reflector | 10.0.58 | → | 10.0.59 | 🟢 |

## Breaking Changes / Upgrade Notes

Patch-only bump (10.0.58 → 10.0.59). No breaking changes reported.

## Impact on Current Setup

No impact — patch version bump with no structural or config changes.

## Changelog

- 10.0.58 → 10.0.59: Minor bug fixes and dependency updates.

## Source

https://github.com/emberstack/helm-charts/releases/tag/reflector-10.0.59