### PR TITLE
chore(deps): kube-prometheus-stack 78.1.0 → 87.15.2

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 78.1.0
+    version: 87.15.2
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 78.1.0 | → | 87.15.2 | 🔴 |

## Breaking Changes / Upgrade Notes

This is a significant jump across 9 major versions (78 → 87). Key changes:

- **78→79**: Grafana admin password no longer has a default. NOT affected — `grafana.enabled: false`.
- **79→80**: Prometheus-Operator v0.87.0 — CRDs need updating.
- **80→81**: Prometheus-Operator v0.88.0 — CRDs need updating.
- **81→82**: Prometheus-Operator v0.89.0 — CRDs need updating.
- **82→83**: Prometheus-Operator v0.90.1 — CRDs need updating.
- **83→84**: Grafana v13.0.0 upgrade. NOT affected — `grafana.enabled: false`.
- **84→85**: Default images switch to distroless variants for prometheus and node-exporter. The `prometheus` image now uses a distroless base. MAY AFFECT — verify prometheus container starts correctly after upgrade.
- **85→86**: Prometheus-Operator v0.91.0 — CRDs need updating.
- **86→87**: Prometheus-Operator v0.92.0 — CRDs need updating.

## Impact on Current Setup

- **Grafana admin password change**: NOT affected — Grafana is disabled (`grafana.enabled: false`).
- **Distroless prometheus images**: MAY AFFECT — The prometheus image switches to distroless. If the setup relies on shell access or sidecars that expect a full image, verify after upgrade. The setup uses only `prometheus.prometheusSpec` storage/retention/OTLP config — no shell-based init containers or probes.
- **CRD upgrades**: AFFECTED — Requires manual CRD update before or during ArgoCD sync. Since the chart uses `includeCRDs: true`, CRDs should update automatically via ArgoCD, but monitoring.coreos.com CRDs may need manual `kubectl apply --server-side` for the new Prometheus-Operator v0.92.0 schema.
- **Node exporter distroless**: NOT affected — `nodeExporter.enabled: false`.
- **Grafana upgrade**: NOT affected — `grafana.enabled: false`.
- **Config keys**: All currently-used keys (`alertmanager.enabled`, `grafana.enabled`, `nodeExporter.enabled`, `kubeStateMetrics.enabled`, `defaultRules.create`, `prometheus.prometheusSpec.*`, `prometheus.route.*`) remain stable across these versions.

## Changelog

Key features between 78.1.0 and 87.15.2:
- Prometheus-Operator v0.86.0 → v0.92.0 (multiple operator enhancements, bug fixes)
- Prometheus updated to latest stable releases
- Support for OTLP receiver (already enabled via `enableOTLPReceiver: true`)
- Distroless image variants by default
- Various bug fixes and dependency updates

Full changelog: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/UPGRADE.md

## Source

https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.15.2