### PR TITLE
chore(deps): pyroscope 1.15.1 → 2.1.1

### DIFF
--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.15.1
+    version: 2.1.1
     releaseName: pyroscope
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| pyroscope | 1.15.1 | → | 2.1.1 | 🔴 |

## Breaking Changes / Upgrade Notes

Pyroscope v2 introduces a completely new storage architecture. The migration requires a **phased approach** — see Grafana migration guide: https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/

Key changes:
- **v2 storage architecture** replaces the v1 ingester/store-gateway/querier/compactor with segment-writer, metastore, compaction-worker, query-backend
- **Object storage required** for v2 block storage — local disk persistence is no longer sufficient for block storage
- **Dual-ingest migration** supported: run both v1 and v2 simultaneously, validate, then remove v1
- Helm chart values restructured: `architecture.storage.v1` / `architecture.storage.v2` toggles
- The `all.enable-v1-write-path` option is replaced with `architecture.storage.v1`
- `persistence.shared` and related settings are removed
- Chart requires first upgrading to 1.19.2+ before v2 migration can start

## Impact on Current Setup

- **Object storage**: AFFECTED — Current setup uses `pyroscope.persistence.existingClaim: pyroscope-pvc` (local PVC). v2 requires object storage (S3/GCS/Azure). The PVC can remain for other data but v2 block storage needs object storage configuration.
- **Storage architecture migration**: AFFECTED — Needs phased migration: 1) upgrade to 1.19.x first, 2) enable dual-ingest with `architecture.storage.v1=true,v2=true`, 3) validate for 24h+, 4) switch to v2-only. This PR bumps directly to 2.1.1 — perform the intermediate 1.19.x upgrade first, then enable v2 in stages.
- **Persistence config**: AFFECTED — `pyroscope.persistence.existingClaim` is used for PVC. In v2, this may still work for metadata but block storage requires object storage.
- **ServiceMonitor**: NOT affected — `serviceMonitor.enabled: true` with labels is still supported.
- **Affinity config**: NOT affected — `pyroscope.affinity` configuration is still supported.
- **Alloy disabled**: NOT affected — `alloy.enabled: false` is still valid.

## Changelog

- v2.0.0: Complete architecture overhaul with v2 storage, dual-ingest migration support
- v2.1.0: Bug fixes, performance improvements
- v2.1.1: Additional stability fixes

Full changelog: https://github.com/grafana/pyroscope/releases

## Source

https://github.com/grafana/helm-charts/releases/tag/pyroscope-2.1.1