### PR TITLE
chore(deps): k8s-monitoring 3.8.10 → 4.2.2

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.10
+    version: 4.2.2
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml

--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -2,14 +2,15 @@
 cluster:
   name: k3s-homelab
 
+# v4: Destinations changed from list to map with unique keys
 destinations:
-  - name: loki
+  loki:
     type: loki
     url: http://loki-gateway/loki/api/v1/push
-  - name: prometheus
+  prometheus:
     type: prometheus
     url: http://prometheus-operated:9090/api/v1/write
-  - name: tempo
+  tempo:
     type: otlp
     url: http://tempo:4317
     tls:
@@ -20,19 +21,28 @@ destinations:
       enabled: false
     traces:
       enabled: true
-  - name: pyroscope
+  pyroscope:
     type: pyroscope
     url: http://pyroscope:4040
 
+# v4: Collectors are user-defined with presets, replacing fixed alloy-* names
+collectors:
+  metrics-collector:
+    presets: [clustered, statefulset]
+  logs-collector:
+    presets: [filesystem-log-reader, daemonset]
+  singleton-collector:
+    presets: [singleton]
+  receiver-collector:
+    presets: [daemonset]
+  profiles-collector:
+    presets: [privileged, daemonset]
+
 clusterMetrics:
   enabled: true
+  collector: metrics-collector
   global:
     scrapeInterval: 30s
-  node-exporter:
-    enabled: true
-    deploy: true
-    metricsTuning:
-      useDefaultAllowList: false
   kubelet:
     metricsTuning:
       useDefaultAllowList: false
@@ -42,21 +52,35 @@ clusterMetrics:
   apiServer:
     enabled: true
 
+# v4: host metrics (node-exporter) split into separate feature
+hostMetrics:
+  enabled: true
+  linuxHosts:
+    enabled: true
+    collector: metrics-collector
+    metricsTuning:
+      useDefaultAllowList: false
+
 clusterEvents:
   enabled: true
+  collector: singleton-collector
 
 nodeLogs:
   enabled: true
+  collector: logs-collector
 
-podLogs:
+podLogsViaLoki:
   enabled: true
+  collector: logs-collector
 
 annotationAutodiscovery:
   enabled: true
   scrapeInterval: 30s
+  collector: metrics-collector
 
 autoInstrumentation:
   enabled: true
+  collector: receiver-collector
   beyla:
     metricsTuning:
       excludeMetrics:
@@ -90,6 +114,7 @@ autoInstrumentation:
 
 applicationObservability:
   enabled: true
+  collector: receiver-collector
   receivers:
     otlp:
       grpc:
@@ -107,31 +132,23 @@ applicationObservability:
 prometheusOperatorObjects:
   enabled: true
 
-# profiling enabled via annotations:
-# ebpf - profiles.grafana.com/cpu.ebpf.enabled="true"
-# java - profiles.grafana.com/java.enabled="true"
-# pprof - profiles.grafana.com/cpu.scrape: "true"
-# pprof - profiles.grafana.com/cpu.port: port
-# pprof - profiles.grafana.com/cpu.port_name: port_name
-# pprof - profiles.grafana.com/cpu.scheme: scheme
-# pprof - profiles.grafana.com/cpu.container: container
+# v4: Profiling requires explicit sub-features
 profiling:
   enabled: true
+  collector: profiles-collector
+  ebpf:
+    enabled: true
+  pprof:
+    enabled: true
+  java:
+    enabled: false
 
-alloy-receiver:
-  enabled: true
-
-alloy-profiles:
-  enabled: true
-
-alloy-metrics:
-  enabled: true
-
-alloy-singleton:
-  enabled: true
-
-alloy-logs:
-  enabled: true
+# v4: Telemetry services are now explicit
+telemetryServices:
+  kube-state-metrics:
+    deploy: true
+  node-exporter:
+    deploy: true
 
 alloy-operator:
   deploy: true
@@ -139,6 +156,7 @@ alloy-operator:
     enabled: false
 
 integrations:
+  collector: metrics-collector
   cert-manager:
     instances:
       - name: cert-manager
@@ -149,7 +167,7 @@ integrations:
     instances:
       - name: alloy
         labelSelectors:
-          app.kubernetes.io/name: 
+          app.kubernetes.io/name:
             - alloy-logs
             - alloy-metrics
             - alloy-receiver


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| k8s-monitoring | 3.8.10 | → | 4.2.2 | 🔴 |

## Breaking Changes / Upgrade Notes

**v4.0 is the largest structural update the chart has received.** Values.yaml format has been completely restructured.

Key changes (see https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/helm-chart-config/helm-chart/migrate-helm-chart/):

1. **Destinations** changed from list to map (keyed by name) — more predictable GitOps overlays
2. **Collectors** are now user-defined with presets, replacing fixed names (`alloy-metrics`, `alloy-logs`, etc.)
3. **Host metrics** (node-exporter) split from `clusterMetrics` into `hostMetrics.linuxHosts`
4. **Telemetry services** (kube-state-metrics, node-exporter, opencost) are now explicit under `telemetryServices`
5. **Pod logs** split into `podLogsViaLoki` / `podLogsViaOpenTelemetry`
6. **Profiling** requires explicit sub-features (`ebpf`, `pprof`, `java`)
7. **Prometheus Operator CRDs** no longer bundled — separate install required (CRDs already present from prometheus-community chart)
8. **Features** now explicitly reference a collector via `collector: <name>`

## Impact on Current Setup

- **Destinations → map**: AFFECTED — Rewritten to map format with custom keys (`loki`, `prometheus`, `tempo`, `pyroscope`).
- **Collectors renamed**: AFFECTED — Replaced `alloy-metrics`/`alloy-logs`/`alloy-singleton`/`alloy-receiver`/`alloy-profiles` with user-defined `metrics-collector`/`logs-collector`/`singleton-collector`/`receiver-collector`/`profiles-collector`.
- **Host metrics moved**: AFFECTED — `clusterMetrics.node-exporter` moved to `hostMetrics.linuxHosts`.
- **Telemetry services explicit**: AFFECTED — `node-exporter` and `kube-state-metrics` now under `telemetryServices`.
- **Profiling sub-features**: NOT affected — eBPF and pprof profilers explicitly enabled.
- **Prometheus Operator CRDs**: NOT affected — CRDs are installed by `kube-prometheus-stack` with `includeCRDs: true`.
- **Backing services (node-exporter, kube-state-metrics)**: AFFECTED — moved from `clusterMetrics.*.deploy` to `telemetryServices.*.deploy`.
- **Integrations**: AFFECTED — Added `collector: metrics-collector` at the top level.
- **Pod logs**: AFFECTED — `podLogs` renamed to `podLogsViaLoki`.
- **Auto-instrumentation**: AFFECTED — Added `collector: receiver-collector`.
- **Application observability**: AFFECTED — Added `collector: receiver-collector`.

## Changelog

- **4.0.0**: Major restructure — destinations as map, user-defined collectors, telemetry services split, profiling sub-features
- **4.1.0**: Data processors, kubernetesEnrichment processor, host metrics alloy source
- **4.2.0**: Linux host metrics via Alloy, data processors GA
- **4.2.1**: New presets (root, host-network, host-storage, host-cgroup), fixes
- **4.2.2**: attachNamespaceMetadata option, Beyla fixes, dependency updates

## Source

https://github.com/grafana/helm-charts/releases/tag/k8s-monitoring-4.2.2