### PR TITLE
fix: SQLite pre-backup — VACUUM INTO local copy before dump

### DIFF
--- a/apps/freshrss/pre-backup-pod.yaml
+++ b/apps/freshrss/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: freshrss-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:

--- a/apps/linkding/pre-backup-pod.yaml
+++ b/apps/linkding/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 .dump'
+  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:
@@ -33,7 +33,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 .dump'
+  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:

--- a/apps/media/jellyfin/pre-backup-pod.yaml
+++ b/apps/media/jellyfin/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: jellyfin-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db .dump'
+  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/media/prowlarr/pre-backup-pod.yaml
+++ b/apps/media/prowlarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: prowlarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/prowlarr.db .dump'
+  backupCommand: sh -c 'sqlite3 /config/prowlarr.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/media/radarr/pre-backup-pod.yaml
+++ b/apps/media/radarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: radarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/radarr.db .dump'
+  backupCommand: sh -c 'sqlite3 /config/radarr.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/media/sonarr/pre-backup-pod.yaml
+++ b/apps/media/sonarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: sonarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/sonarr.db .dump'
+  backupCommand: sh -c 'sqlite3 /config/sonarr.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/observability/grafana/pre-backup-pod.yaml
+++ b/apps/observability/grafana/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: grafana
 spec:
-  backupCommand: sh -c 'sqlite3 /data/grafana.db .dump'
+  backupCommand: sh -c 'sqlite3 /data/grafana.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/wallabag/pre-backup-pod.yaml
+++ b/apps/wallabag/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: wallabag-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:


### PR DESCRIPTION
## Problem

All 8 SQLite-backed pre-backup pods run `.dump` directly against the NFS-mounted database file. SQLite's POSIX file locking is unreliable over NFS — when the running app holds a write transaction (especially with WAL mode), `.dump` fails with `database is locked` immediately and the backup fails.

## Solution

Wrap each dump in a two-step process:

1. `VACUUM INTO '/tmp/copy.sqlite'` — creates a fresh, defragmented copy of the database on the sidecar's **local tmpfs** (no NFS). Uses the backup API internally, works while the source is being written to, and handles WAL mode correctly.
2. `.dump` from the local copy — no NFS involved, no locking issues.

## Apps Changed

| App | DB Path |
|---|---|
| wallabag | `/data/db/wallabag.sqlite` |
| linkding (DB1) | `/data/db.sqlite3` |
| linkding (DB2) | `/data/tasks.sqlite3` |
| freshrss | `/data/www/freshrss/data/users/gedas/db.sqlite` |
| grafana | `/data/grafana.db` |
| sonarr | `/config/sonarr.db` |
| radarr | `/config/radarr.db` |
| prowlarr | `/config/prowlarr.db` |
| jellyfin | `/config/data/data/jellyfin.db` |

## Files Changed

```
apps/freshrss/pre-backup-pod.yaml                  | 2 +-
apps/linkding/pre-backup-pod.yaml                  | 4 ++--
apps/media/jellyfin/pre-backup-pod.yaml            | 2 +-
apps/media/prowlarr/pre-backup-pod.yaml            | 2 +-
apps/media/radarr/pre-backup-pod.yaml              | 2 +-
apps/media/sonarr/pre-backup-pod.yaml              | 2 +-
apps/observability/grafana/pre-backup-pod.yaml     | 2 +-
apps/wallabag/pre-backup-pod.yaml                  | 2 +-
8 files changed, 9 insertions(+), 9 deletions(-)
```

## Verification

Tested the shell quoting (`\\'\\'` embedded single-quote pattern) locally — produces correct SQL: `VACUUM INTO '/tmp/copy.sqlite'`