### PR TITLE
fix: grant hermes-agent create on k8up.io/backups

### DIFF
--- a/apps/hermes/rbac.yaml
+++ b/apps/hermes/rbac.yaml
@@ -32,6 +32,12 @@ rules:
       - list
       - watch
       - delete
+  - apiGroups:
+      - k8up.io
+    resources:
+      - backups
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What

Adds a rule to the hermes-agent ClusterRole allowing `create` on `backups.k8up.io` resources.

## Why

The VACUUM INTO pre-backup fix (PR #326) is live in the cluster but can't be tested without triggering a manual backup. The agent currently has get/list/watch on all resources plus pod create/delete, but can't create `Backup` resources to run on-demand backups.

## Impact

Minimal. This only adds `create` for `backups` in the `k8up.io` group — no other k8up resources (Schedules, Restores, etc.) are affected.