### PR TITLE
fix: use .clone instead of VACUUM INTO for pre-backup pods

### DIFF
--- a/apps/freshrss/pre-backup-pod.yaml
+++ b/apps/freshrss/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: freshrss-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:

--- a/apps/linkding/pre-backup-pod.yaml
+++ b/apps/linkding/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:
@@ -33,7 +33,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:

--- a/apps/media/jellyfin/pre-backup-pod.yaml
+++ b/apps/media/jellyfin/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: jellyfin-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/media/prowlarr/pre-backup-pod.yaml
+++ b/apps/media/prowlarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: prowlarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/prowlarr.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/media/radarr/pre-backup-pod.yaml
+++ b/apps/media/radarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: radarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/radarr.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/radarr.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/media/sonarr/pre-backup-pod.yaml
+++ b/apps/media/sonarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: sonarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/sonarr.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/sonarr.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/observability/grafana/pre-backup-pod.yaml
+++ b/apps/observability/grafana/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: grafana
 spec:
-  backupCommand: sh -c 'sqlite3 /data/grafana.db "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/grafana.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       containers:

--- a/apps/wallabag/pre-backup-pod.yaml
+++ b/apps/wallabag/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: wallabag-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite "VACUUM INTO '\''/tmp/copy.sqlite'\''" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
   pod:
     spec:
       securityContext:


### PR DESCRIPTION
## What

Replaces the VACUUM INTO approach from PR #326 with `sqlite3 .clone` — functionally equivalent but with shell quoting that survives k8up's exec command reconstruction.

## Root Cause

PR #326 used `VACUUM INTO '\\''/tmp/copy.sqlite'\\''` which relies on the `'\\''` shell quoting pattern (close-quote, escaped-quote, reopen-quote). This pattern is mangled when k8up splits the `backupCommand` on whitespace and joins it back — the shell receives a malformed string and errors with `unterminated quoted string`.

## Fix

`sqlite3 .clone /tmp/copy.sqlite` instead — a dot-command that uses the SQLite backup API (same local copy + dump logic) with zero nested quoting:

```
sh -c 'sqlite3 /path/to/db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
```

## Verification

The .clone backup API works on live databases while the source is being written to, handles WAL mode correctly, and writes the copy to the sidecar's local tmpfs (no NFS). All 8 apps updated.