### PR TITLE
fix: use .timeout + .backup for SQLite pre-backup pods

### DIFF
--- a/apps/freshrss/pre-backup-pod.yaml
+++ b/apps/freshrss/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: freshrss-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       securityContext:

--- a/apps/linkding/pre-backup-pod.yaml
+++ b/apps/linkding/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       securityContext:
@@ -33,7 +33,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       securityContext:

--- a/apps/media/jellyfin/pre-backup-pod.yaml
+++ b/apps/media/jellyfin/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: jellyfin-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       containers:

--- a/apps/media/prowlarr/pre-backup-pod.yaml
+++ b/apps/media/prowlarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: prowlarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       containers:

--- a/apps/media/radarr/pre-backup-pod.yaml
+++ b/apps/media/radarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: radarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/radarr.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/radarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       containers:

--- a/apps/media/sonarr/pre-backup-pod.yaml
+++ b/apps/media/sonarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: sonarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/sonarr.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /config/sonarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       containers:

--- a/apps/observability/grafana/pre-backup-pod.yaml
+++ b/apps/observability/grafana/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: grafana
 spec:
-  backupCommand: sh -c 'sqlite3 /data/grafana.db ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/grafana.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       containers:

--- a/apps/wallabag/pre-backup-pod.yaml
+++ b/apps/wallabag/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: wallabag-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite ".clone /tmp/copy.sqlite" && sqlite3 /tmp/copy.sqlite .dump'
+  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
   pod:
     spec:
       securityContext:


### PR DESCRIPTION
## What

Swaps the SQLite backup command from `.clone` to `.backup` + `.timeout 30000` across all 8 pre-backup pods.

## Why

Research revealed `.clone` does **not** use SQLite's Online Backup API — it opens a second connection and copies data via plain SQL `SELECT` statements without a read transaction wrapper or busy handler. This causes:

- **SQLITE_PROTOCOL (15)** on linkding — NFS lock conflict with no retry mechanism
- **Empty dumps** on prowlarr — WAL mode content not properly read over NFS

## The Fix

```
sqlite3 /data/app.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"
```

Three changes in one:

| Change | Why |
|---|---|
| **.timeout 30000** | Sets 30s busy timeout on the source connection. Default is 0 — immediate failure on lock conflict. The Backup API respects this for retry. |
| **.backup /tmp/backup.sqlite** | Uses sqlite3_backup_init/step/finish — the Online Backup API. Holds locks briefly, auto-restarts on concurrent writes, reads WAL content correctly. |
| **.dump** wrapped in double-quotes | Matches the clean quoting pattern: all dot-command args use ".command args" syntax that survives k8up's exec split+rejoin. |

## Apps Changed

All 8 SQLite-backed apps: wallabag, linkding (x2 DBs), freshrss, grafana, sonarr, radarr, prowlarr, jellyfin.

Single-line change per pre-backup-pod.yaml — same pattern across all.

## Research Sources

- SQLite Backup API docs: sqlite.org/backup.html
- SQLite shell.c source (confirmed .clone != .backup)
- SQLite forum: .clone behavior with concurrent writes
- NFS SQLITE_PROTOCOL analysis
