### PR TITLE
fix: use .timeout + .dump for linkding and prowlarr

### DIFF
--- a/apps/linkding/pre-backup-pod.yaml
+++ b/apps/linkding/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".timeout 30000" ".dump"'
   pod:
     spec:
       securityContext:
@@ -33,7 +33,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".timeout 30000" ".dump"'
   pod:
     spec:
       securityContext:

--- a/apps/media/prowlarr/pre-backup-pod.yaml
+++ b/apps/media/prowlarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: prowlarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".timeout 30000" ".dump"'
   pod:
     spec:
       containers:


### PR DESCRIPTION
## What

Linkding and prowlarr produce empty SQLite dumps with `.backup`. The Online Backup API retries for the full `.timeout` but on NFS with persistent app write locks, it creates an empty/truncated file and exits 0 — silently producing worthless backups.

## Fix

Swap just these two apps to `.timeout 30000` + `.dump` directly:

```
sqlite3 /data/db.sqlite3 ".timeout 30000" ".dump"
```

Why this works when `.backup` doesn't:
- `.dump` uses a simple read transaction — faster lock acquisition than the backup API
- `.timeout 30000` retries for 30s before giving up (original `.dump` had zero retry)
- When the app isn't mid-transaction, `.dump` completes immediately
- `.backup`'s incremental page-by-page approach is more susceptible to NFS WAL/shm file conflicts

## Other 6 apps unchanged

wallabag, freshrss, grafana, sonarr, radarr, jellyfin keep `.timeout 30000` + `.backup /tmp/x` + `.dump` — all verified with real data in restic snapshots.
