### PR TITLE
fix: unify all SQLite pre-backup pods to .timeout 120000 + .dump

### DIFF
--- a/apps/freshrss/pre-backup-pod.yaml
+++ b/apps/freshrss/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: freshrss-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/www/freshrss/data/users/gedas/db.sqlite ".timeout 120000" ".dump"'
   pod:
     spec:
       securityContext:

--- a/apps/linkding/pre-backup-pod.yaml
+++ b/apps/linkding/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/db.sqlite3 ".timeout 120000" ".dump"'
   pod:
     spec:
       securityContext:
@@ -33,7 +33,7 @@ metadata:
   labels:
     name: linkding
 spec:
-  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/tasks.sqlite3 ".timeout 120000" ".dump"'
   pod:
     spec:
       securityContext:

--- a/apps/media/jellyfin/pre-backup-pod.yaml
+++ b/apps/media/jellyfin/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: jellyfin-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /config/data/data/jellyfin.db ".timeout 120000" ".dump"'
   pod:
     spec:
       containers:

--- a/apps/media/prowlarr/pre-backup-pod.yaml
+++ b/apps/media/prowlarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: prowlarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /config/prowlarr.db ".timeout 120000" ".dump"'
   pod:
     spec:
       containers:

--- a/apps/media/radarr/pre-backup-pod.yaml
+++ b/apps/media/radarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: radarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/radarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /config/radarr.db ".timeout 120000" ".dump"'
   pod:
     spec:
       containers:

--- a/apps/media/sonarr/pre-backup-pod.yaml
+++ b/apps/media/sonarr/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: sonarr-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /config/sonarr.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /config/sonarr.db ".timeout 120000" ".dump"'
   pod:
     spec:
       containers:

--- a/apps/observability/grafana/pre-backup-pod.yaml
+++ b/apps/observability/grafana/pre-backup-pod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     name: grafana
 spec:
-  backupCommand: sh -c 'sqlite3 /data/grafana.db ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/grafana.db ".timeout 120000" ".dump"'
   pod:
     spec:
       containers:

--- a/apps/wallabag/pre-backup-pod.yaml
+++ b/apps/wallabag/pre-backup-pod.yaml
@@ -4,7 +4,7 @@ kind: PreBackupPod
 metadata:
   name: wallabag-db-dump
 spec:
-  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite ".timeout 30000" ".backup /tmp/backup.sqlite" && sqlite3 /tmp/backup.sqlite ".dump"'
+  backupCommand: sh -c 'sqlite3 /data/db/wallabag.sqlite ".timeout 120000" ".dump"'
   pod:
     spec:
       securityContext:


### PR DESCRIPTION
## What

Unify all 8 SQLite pre-backup pods to a single simple command:

```
sqlite3 /path/to/db ".timeout 120000" ".dump"
```

Two changes from the current state (`.timeout 30000` + `.backup /tmp/x` + `.dump`):

| Change | Why |
|---|---|
| **`.timeout 120000`** (was 30000) | 2-minute busy timeout. Some apps (linkding, prowlarr) hold write locks longer than 30s on NFS. 120s gives enough margin. |
| **`.dump` directly** (was `.backup` + `.dump`) | The Online Backup API on NFS with persistent app write locks produces **empty/truncated backup files** (exits 0, creates `BEGIN TRANSACTION; COMMIT;` — worthless). `.dump` has a cleaner contract: acquire one read lock with retry, produce real data or fail. |

Apps that worked with `.backup` (wallabag, freshrss, grafana, sonarr, radarr, jellyfin) will work identically with `.dump` — they don't have persistent lock conflicts. Apps that didn't (linkding, prowlarr) get a real chance with the 120s timeout.
