### PR TITLE
fix: immich backup schedule — day 7 → 0

### DIFF
--- a/apps/immich/backup-schedule.yaml
+++ b/apps/immich/backup-schedule.yaml
@@ -20,7 +20,7 @@ spec:
         name: backup-secret
         key: b2-account-key
   backup:
-    schedule: '01 00 * * 7'
+    schedule: '01 00 * * 0'
     failedJobsHistoryLimit: 2
     successfulJobsHistoryLimit: 2
   check:


### PR DESCRIPTION
## What

Immich backup schedule uses `01 00 * * 7` (Sunday at 00:01) but k8up's cron parser expects Sunday=0. Day 7 is out of range, causing:

```
ERROR - cannot set schedule: end of range (7) above maximum (6): 7
```

This error fires every ~20 minutes and the schedule **never registers** — immich has not been backed up at all.

## Fix

`7` → `0` — `01 00 * * 0` (Sunday at 00:01, Sun=0)