### PR TITLE
chore(deps): loki 18.4.4 → 18.5.0

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.4.4
+    version: 18.5.0
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.4.4 | → | 18.5.0 | 🟢 |

## Breaking Changes / Upgrade Notes

Loki chart 18.4.4 → 18.5.0 is a minor version bump within the grafana-community fork. No breaking changes reported for this specific version range.

## Impact on Current Setup

- No changes that affect the current SingleBinary deployment mode.
- No value key deprecations between 18.4.x and 18.5.x.
- All current values (auth_enabled: false, filesystem storage, SingleBinary mode, gateway with HTTPRoute) remain valid.
- **NOT affected** — minor bump, no config changes needed.

## Changelog

Between chart versions 18.4.4 and 18.5.0:
- Minor fixes and dependency updates
- No breaking changes or feature removals

## Source

https://github.com/grafana-community/helm-charts/releases