### PR TITLE
chore(deps): reflector 10.0.58 → 10.0.60

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -12,7 +12,7 @@ helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
     namespace: cert-manager
-    version: 10.0.58
+    version: 10.0.60
     releaseName: reflector
 
 #patches:


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| reflector | 10.0.58 | → | 10.0.60 | 🟢 |

## Breaking Changes / Upgrade Notes

Patch-level bump (10.0.58 → 10.0.60). No breaking changes reported for this version range.

## Impact on Current Setup

- **NOT affected** — patch bump, no config changes needed.

## Changelog

v10.0.59:
- Dependency updates (dependabot)

v10.0.60:
- Dependency updates (dependabot)

## Source

https://github.com/emberstack/kubernetes-reflector/releases/tag/v10.0.60