### PR TITLE
chore(deps): tempo 1.24.4 → 2.2.3

### DIFF
--- a/apps/observability/tempo/kustomization.yaml
+++ b/apps/observability/tempo/kustomization.yaml
@@ -6,9 +6,9 @@ namespace: observability
 
 helmCharts:
   - name: tempo
-    repo: https://grafana.github.io/helm-charts
+    repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 1.24.4
+    version: 2.2.3
     releaseName: tempo
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| tempo (chart) | 1.24.4 | → | 2.2.3 | 🟡 |
| tempo (app) | 2.9.0 | → | 2.10.7 | 🟡 |

## Breaking Changes / Upgrade Notes

### Chart repo migration
The Tempo Helm chart has moved from the official Grafana repository (`grafana.github.io/helm-charts`) to the community fork (`grafana-community.github.io/helm-charts`) as part of Grafana's shift to focus on Grafana Cloud charts. The community fork continues OSS chart releases.

### Tempo app 2.9.0 → 2.10.7
- **No breaking changes** — this is a minor/bugfix release within the 2.x line
- Key changes: bug fixes, performance improvements, security patches
- The v3.0.0 release exists but is not targeted here — staying on 2.x for stability

### Helm chart 1.x → 2.x
- Chart 2.x is a new major version from the community fork reflecting the repo migration and updated dependencies
- The values structure remains compatible with 1.x
- `extraVolumes` and `extraVolumeMounts` continue to work as before
- `tempo.metricsGenerator` config structure is unchanged

## Impact on Current Setup

- **NOT affected** — current values.yaml continues to work with chart 2.x:
  - `extraVolumes` / `extraVolumeMounts` for PVC: still supported
  - `tempo.metricsGenerator.enabled: true`: still supported
  - `tempo.retention: "72h"`: still supported
  - `tempo.overrides.defaults.metrics_generator.processors`: still supported
  - `affinity` settings: still supported
  - The community fork maintains backward compatibility with existing values

## Changelog

Between tempo chart 1.24.4 (app 2.9.0) and chart 2.2.3 (app 2.10.7):
- Chart repo migrated to grafana-community/helm-charts
- App version updated from 2.9.0 to 2.10.7
- Bug fixes and dependency updates
- Removal of deprecated config options (none affecting this deployment)

## Source

- Chart: https://artifacthub.io/packages/helm/grafana-community/tempo
- App releases: https://github.com/grafana/tempo/releases/tag/v2.10.7