### PR TITLE
chore(deps): kube-prometheus-stack 78.1.0 → 87.16.1

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 78.1.0
+    version: 87.16.1
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 78.1.0 | → | 87.16.1 | 🟡 |

## Breaking Changes / Upgrade Notes

### 78.x → 79.x
- Grafana admin password default removed (was `prom-operator`), now randomly generated
- **Impact on Current Setup: NOT affected** — `grafana.enabled: false` in values

### 72.x → 73.x
- Removed deprecated K8s Ingress API versions and PodSecurityPolicy support
- Requires K8s >= 1.25
- **Impact on Current Setup: NOT affected** — cluster is K3s on recent K8s, no PSPs or Ingresses used

### 71.x → 72.x
- PDBs now require explicit `enabled: true` flag
- **Impact on Current Setup: NOT affected** — no PDBs configured

### 66.x → 67.x
- Prometheus image upgraded to v3.0.1 (breaking config changes)
- **Impact on Current Setup: MAY AFFECT** — `enableRemoteWriteReceiver` and `enableOTLPReceiver` are supported in Prometheus 3.x but verify after upgrade

### 67.x → 68.x
- Dropped excessive histogram buckets and high-cardinality metrics by default
- **Impact on Current Setup: NOT affected** — beneficial change, reduces storage

### CRD upgrades (v0.86 → v0.92)
Every major prometheus-operator version requires CRD updates:
```bash
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.92.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
```

## Impact on Current Setup

- `grafana.enabled: false`: NOT affected by grafana password change
- `alertmanager.enabled: false`: NOT affected
- `defaultRules.create: false`: NOT affected by rule changes
- `prometheus.prometheusSpec.enableRemoteWriteReceiver`: MAY AFFECT — verify after upgrade
- `prometheus.prometheusSpec.enableOTLPReceiver`: MAY AFFECT — verify after upgrade
- `prometheus.prometheusSpec.storageSpec`: NOT affected — PVC template still supported
- `prometheus.prometheusSpec.affinity`: NOT affected — still supported
- All disabled components (grafana, nodeExporter, kubeStateMetrics, kubernetesServiceMonitors): NOT affected

**Manual step required:** CRDs must be updated to v0.92.0 before or during the ArgoCD sync.

## Changelog

Key changes across 78.1.0 → 87.16.1:
- Prometheus-Operator: v0.86.0 → v0.92.0
- Prometheus: v2.x → v3.0.1+
- Various dependency bumps (kube-state-metrics, node-exporter, grafana subcharts)
- Metrics cardinality reduction defaults
- Removal of PSP and deprecated Ingress API support
- Grafana admin password now auto-generated (not affected — grafana disabled)

## Source

https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.16.1