### PR TITLE
chore(deps): opentelemetry-operator 0.119.0 → 0.120.0

### DIFF
--- a/apps/observability/opentelemetry-operator/kustomization.yaml
+++ b/apps/observability/opentelemetry-operator/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: opentelemetry-operator
     repo: https://open-telemetry.github.io/opentelemetry-helm-charts
     namespace: observability
-    version: 0.119.0
+    version: 0.120.0
     releaseName: opentelemetry-operator
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| opentelemetry-operator | 0.119.0 | → | 0.120.0 | 🟢 |

## Breaking Changes / Upgrade Notes

No breaking changes. This chart bump updates the operator from v0.155.x to v0.156.0. The only change is a bug fix:

- **Bug fix**: `spec.observability.metrics.disablePrometheusAnnotations: true` now properly strips existing prometheus.io/* annotations on update instead of leaving stale ones on rolled pods.

## Impact on Current Setup

Current `values.yaml`:
```yaml
manager:
  metrics:
    secure: false
  autoInstrumentation:
    go:
      enabled: true
```

| Change | Affected? | Details |
|---|---|---|
| Prometheus annotation bug fix | ❌ Not affected | We don't set `disablePrometheusAnnotations` — the bug fix is additive and only affects users who toggle that setting. |
| auto-instrumentation SDK bumps | ❌ Not affected | Go auto-instrumentation (our `manager.autoInstrumentation.go.enabled: true`) continues to be managed by the operator — the SDK update is transparent. |
| `manager.metrics.secure: false` | ✅ Fully compatible | Chart 0.120.0 still supports this value. |

**Verdict**: Safe bump, no config changes needed.

## Changelog

- opentelemetry-operator v0.156.0: Bug fix for Prometheus annotation cleanup on update
- OpenTelemetry Collector v0.156.0
- OpenTelemetry Contrib v0.156.0
- Java auto-instrumentation v2.29.0
- .NET auto-instrumentation v1.16.0
- Node.js v0.78.0
- Python v0.64b0
- Go v0.24.0

## Source

https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.120.0
https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.156.0