### PR TITLE
feat: add actualbudget app with NFS persistence and gateway route

### DIFF
--- a/apps/actualbudget/deployment.yaml
+++ b/apps/actualbudget/deployment.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: actualbudget
+  labels:
+    app: actualbudget
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: actualbudget
+  template:
+    metadata:
+      labels:
+        app: actualbudget
+    spec:
+      containers:
+        - name: actualbudget
+          image: actualbudget/actual-server:26.7.0
+          ports:
+            - containerPort: 5006
+          env:
+            - name: TZ
+              value: Europe/Vilnius
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: actualbudget-data

--- a/apps/actualbudget/httproute.yaml
+++ b/apps/actualbudget/httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: actualbudget
+spec:
+  hostnames:
+    - actualbudget.g2net.xyz
+  parentRefs:
+    - name: cilium-shared-gateway
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: actualbudget
+          port: 80
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-redirect-actualbudget
+spec:
+  parentRefs:
+    - name: cilium-shared-gateway
+      namespace: kube-system
+      sectionName: http
+  hostnames:
+    - actualbudget.g2net.xyz
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/apps/actualbudget/kustomization.yaml
+++ b/apps/actualbudget/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: actualbudget
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - pvc.yaml

--- a/apps/actualbudget/pvc.yaml
+++ b/apps/actualbudget/pvc.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: actualbudget-data
+  annotations:
+    k8up.io/backup: true
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: actualbudget-data
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 1Mi
+  volumeMode: Filesystem
+  claimRef:
+    name: actualbudget-data
+    namespace: actualbudget
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Delete
+  nfs:
+    path: /mnt/fast/actualbudget
+    server: 192.168.0.222
+  mountOptions:
+    - noatime
+    - hard
+    - timeo=600
+    - retrans=2

--- a/apps/actualbudget/service.yaml
+++ b/apps/actualbudget/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: actualbudget
+spec:
+  selector:
+    app: actualbudget
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 5006

--- a/argocd/apps/actualbudget.yaml
+++ b/argocd/apps/actualbudget.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: actualbudget
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  destination:
+    namespace: actualbudget
+    server: https://kubernetes.default.svc
+  source:
+    path: apps/actualbudget
+    repoURL: https://github.com/gedulis12/homelab
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Adds **Actual Budget** to the homelab — a personal finance tracking app.

**Patterns used:**
- **Deployment** with pinned image `actualbudget/actual-server:26.7.0` (arm64 compatible)
- **Service** mapping port 80 → container 5006
- **HTTPRoute** exposing at `actualbudget.g2net.xyz` with https redirect
- **PVC + PV** backed by NFS at `192.168.0.222:/mnt/fast/actualbudget`
- **Data persistent** at `/data` inside the container
- **k8up backup** annotation on the PVC
- **ArgoCD Application** matching repo conventions (no HTTPRoute ignoreDifferences needed — no Gateway normalization issues expected)

| Resource | File |
|---|---|
| Kustomization | `apps/actualbudget/kustomization.yaml` |
| Deployment | `apps/actualbudget/deployment.yaml` |
| Service | `apps/actualbudget/service.yaml` |
| HTTPRoute | `apps/actualbudget/httproute.yaml` |
| PVC + PV | `apps/actualbudget/pvc.yaml` |
| ArgoCD Application | `argocd/apps/actualbudget.yaml` |

> ⚠️ The NFS export at `/mnt/fast/actualbudget` needs to exist on the NAS before sync. First-time setup creates the directory structure on deploy.