### PR TITLE
feat: add actualbudget backup schedule with complete data capture

### DIFF
--- a/apps/actualbudget/backup-schedule.yaml
+++ b/apps/actualbudget/backup-schedule.yaml
@@ -1,0 +1,31 @@
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: actualbudget-backup-schedule
+spec:
+  backend:
+    repoPasswordSecretRef:
+      name: backup-secret
+      key: restic-password
+    b2:
+      bucket: g2net-homelab-backup
+      path: actualbudget
+      accountIDSecretRef:
+        name: backup-secret
+        key: b2-account-id
+      accountKeySecretRef:
+        name: backup-secret
+        key: b2-account-key
+  backup:
+    schedule: '@weekly-random'
+    failedJobsHistoryLimit: 2
+    successfulJobsHistoryLimit: 2
+  check:
+    schedule: '@monthly-random'
+  prune:
+    schedule: '@monthly-random'
+    retention:
+      keepLast: 2
+      keepWeekly: 4
+      keepMonthly: 3
+      keepYearly: 2

--- a/apps/actualbudget/kustomization.yaml
+++ b/apps/actualbudget/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - service.yaml
   - httproute.yaml
   - pvc.yaml
+  - pre-backup-pod.yaml
+  - backup-schedule.yaml

--- a/apps/actualbudget/pre-backup-pod.yaml
+++ b/apps/actualbudget/pre-backup-pod.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: k8up.io/v1
+kind: PreBackupPod
+metadata:
+  name: actualbudget-db-dump
+  labels:
+    name: actualbudget
+spec:
+  backupCommand: sh -c 'mkdir -p /tmp/actualbudget-backup && for db in /data/server-files/account.sqlite /data/user-files/*.sqlite; do [ -f "$db" ] || continue; sqlite3 "$db" ".timeout 30000" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null; name=$(basename "$db" .sqlite); cp "$db" "/tmp/actualbudget-backup/${name}.sqlite" && sqlite3 "/tmp/actualbudget-backup/${name}.sqlite" ".dump" > "/tmp/actualbudget-backup/${name}.sql"; done && cp /data/user-files/*.blob /tmp/actualbudget-backup/ 2>/dev/null || true && cp /data/.migrate /tmp/actualbudget-backup/ 2>/dev/null || true && tar cz -C /tmp/actualbudget-backup .'
+  pod:
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+        - name: actualbudget-sqlite-dump
+          image: alpine/sqlite:3.53.2
+          command:
+            - 'sleep'
+            - 'infinity'
+          volumeMounts:
+            - name: actualbudget-data
+              mountPath: /data
+      volumes:
+        - name: actualbudget-data
+          persistentVolumeClaim:
+            claimName: actualbudget-data


### PR DESCRIPTION
## Summary

Adds k8up backup schedule + PreBackupPod for Actual Budget, covering ALL data — not just SQLite.

**PreBackupPod** dumps everything to stdout as a tar.gz:
| Data | Source | Backup format |
|---|---|---|
| Server account DB | `/data/server-files/account.sqlite` | SQL dump via `.dump` (consistent snapshot) |
| User budget DB | `/data/user-files/group-*.sqlite` | SQL dump via `.dump` (consistent snapshot) |
| File attachments | `/data/user-files/*.blob` | Raw copy (write-once files, no consistency issue) |
| Migration marker | `/data/.migrate` | Raw copy |

For each SQLite DB: `cp` to tmpfs → `.dump` — bypasses NFS locking, same pattern as freshrss/linkding.

**Schedule** — same as every other app:
- `@weekly-random` backup
- `@monthly-random` check + prune
- Retention: 2 last, 4 weekly, 3 monthly, 2 yearly

**B2 path:** `actualbudget` (namespace-matching pattern)
