### PR TITLE
chore(deps): k8s-monitoring 3.8.10 → 3.8.11

### DIFF
--- a/apps/observability/k8s-monitoring-helm/kustomization.yaml
+++ b/apps/observability/k8s-monitoring-helm/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: k8s-monitoring
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 3.8.10
+    version: 3.8.11
     releaseName: k8s-monitoring
     includeCRDs: true
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| k8s-monitoring | 3.8.10 | → | 3.8.11 | 🟢 |

> Pinned to 3.x line per user preference. 3.8.11 is the latest patch within the 3.x range. No upgrade to 4.x is suggested.

## Breaking Changes / Upgrade Notes

**No breaking changes.** This is a patch bump within the 3.8.x line. All values, APIs, and behaviors are backward-compatible.

## Impact on Current Setup

- **NOT affected** — all current config keys in `values.yaml` remain valid in 3.8.11
- **NOT affected** — no deprecated keys or removed features in this patch release
- **Dependency updates** — Alloy Operator 0.6.1, Beyla 1.16.10, kube-state-metrics 7.8.1, Node Exporter 4.56.1, OpenCost 2.5.26, Prometheus Operator CRDs 30.0.1 are backward-compatible

## Changelog

**3.8.11** (2026-07-16):
- Add ability to set resolver and timeout for `processors.serviceGraphMetrics` in OTLP destinations
- Add missing extra metric processing rules for Istio metrics integration
- Dependency updates: Alloy Operator → 0.6.1, Beyla → 1.16.10, kube-state-metrics → 7.8.1, Node Exporter → 4.56.1, OpenCost → 2.5.26, Prometheus Operator CRDs → 30.0.1
- Add `openTelemetryConversion.keepIdentifyingResourceAttributes` option to Prometheus destinations

Full changelog: https://github.com/grafana/k8s-monitoring-helm/blob/k8s-monitoring-3.8.11/charts/k8s-monitoring/CHANGELOG.md

## Source

https://github.com/grafana/k8s-monitoring-helm/releases/tag/k8s-monitoring-3.8.11