### PR TITLE
chore(deps): k8up 4.9.0 → 4.10.0

### DIFF
--- a/apps/backup/kustomization.yaml
+++ b/apps/backup/kustomization.yaml
@@ -8,10 +8,10 @@ helmCharts:
   - name: k8up
     repo: https://k8up-io.github.io/k8up
     namespace: backup
-    version: 4.9.0
+    version: 4.10.0
     releaseName: k8up
     valuesFile: values.yaml
 
 resources:
   - sealed-secret.yaml
-  - https://github.com/k8up-io/k8up/releases/download/k8up-4.9.0/k8up-crd.yaml
+  - https://github.com/k8up-io/k8up/releases/download/k8up-4.10.0/k8up-crd.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| k8up | 4.9.0 | → | 4.10.0 | 🟢 |

## Breaking Changes / Upgrade Notes

No breaking changes. This release contains only Helm chart improvements:

- **New features**: `nodeSelector`, `tolerations`, `affinity` added to cleanup hook; `BACKUP_GLOBAL_SKIP_SNAPSHOT_SYNC` flag added
- **Fixes**: `imagePullSecrets` now passed to cleanup job; `globalResources` env var names corrected; SPDY streaming replaced with WebSockets
- **Dependency updates**: Chart bumped for new releases

## Impact on Current Setup

- **SPDY → WebSockets**: NOT affected — this is an internal change to how `kubectl exec` connectivity works in backup pods. No configuration change needed.
- **`nodeSelector`/`tolerations`/`affinity` for cleanup hook**: NOT affected — current `values.yaml` does not set `affinity` or `tolerations` on the cleanup hook, but this only means defaults apply.
- **`imagePullSecrets` fix**: NOT affected — no imagePullSecrets are used in this deployment.
- **`BACKUP_GLOBAL_SKIP_SNAPSHOT_SYNC`**: NOT affected — not configured, defaults to `false` (existing behavior unchanged).

**Verification**: After upgrade, run a test backup to confirm connectivity and snapshot behavior unchanged.

## Changelog

- Add nodeSelector, tolerations, and affinity to cleanup hook (PR #1175)
- Add BACKUP_GLOBAL_SKIP_SNAPSHOT_SYNC flag (PR #1196)
- Fix: pass imagePullSecrets to cleanup job (PR #1222)
- Fix globalResources env var names (PR #1168)
- Use websockets instead of SPDY for streaming (PR #1183)
- Bump chart version (PRs #1185, #1236)

## Source

https://github.com/k8up-io/k8up/releases/tag/k8up-4.10.0