### PR TITLE
chore(deps): loki 18.5.0 → 18.5.1

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.5.0
+    version: 18.5.1
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.5.0 | → | 18.5.1 | 🟢 |

## Breaking Changes / Upgrade Notes

No breaking changes. This is a patch release containing only dependency updates.

## Impact on Current Setup

- **rollout-operator update to v0.50.1**: NOT affected — the rollout-operator is an internal dependency for Loki microservice mode. Current configuration (simple scalable mode with `loki.schemaConfig` and single binary sizing) is unaffected.
- **No values changes**: NOT affected — the 18.5.1 release has no chart values changes from 18.5.0. No migration or config changes needed.

**No action required.** Standard ArgoCD sync will pick up the new version.

## Changelog

- Update Helm release rollout-operator to v0.50.1 (PR #680)

## Source

https://github.com/grafana-community/helm-charts/releases/tag/loki-18.5.1