### PR TITLE
chore(deps): kube-prometheus-stack 78.1.0 -> 87.17.0

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 78.1.0
+    version: 87.17.0
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 78.1.0 | -> | 87.17.0 | YELLOW |

> Supersedes PR #337 (kube-prometheus-stack 78.1.0 -> 87.16.1) -- 87.17.0 is now the latest.

## Breaking Changes / Upgrade Notes

### 78.x -> 79.x
- Grafana admin password default removed (was `prom-operator`), now randomly generated
- **Impact on Current Setup: NOT affected** -- `grafana.enabled: false` in values

### 72.x -> 73.x
- Removed deprecated K8s Ingress API versions and PodSecurityPolicy support
- Requires K8s >= 1.25
- **Impact on Current Setup: NOT affected** -- cluster is K3s on recent K8s, no PSPs or Ingresses used

### 71.x -> 72.x
- PDBs now require explicit `enabled: true` flag
- **Impact on Current Setup: NOT affected** -- no PDBs configured

### 66.x -> 67.x
- Prometheus image upgraded to v3.0.1 (breaking config changes)
- **Impact on Current Setup: MAY AFFECT** -- `enableRemoteWriteReceiver` and `enableOTLPReceiver` are supported in Prometheus 3.x but verify after upgrade

### 67.x -> 68.x
- Dropped excessive histogram buckets and high-cardinality metrics by default
- **Impact on Current Setup: NOT affected** -- beneficial change, reduces storage

### CRD upgrades (v0.86 -> v0.92.0)
Every major prometheus-operator version requires CRD updates. The chart includes CRDs (includeCRDs: true), so ArgoCD will apply them automatically during sync.

## Impact on Current Setup

Based on values at `apps/observability/prometheus/kube-prometheus-stack-values.yaml`:

| Setting | Verdict | Notes |
|---|---|---|
| `grafana.enabled: false` | NOT affected | Grafana password change irrelevant |
| `alertmanager.enabled: false` | NOT affected | Not deployed |
| `defaultRules.create: false` | NOT affected | No rule changes to worry about |
| `prometheus.prometheusSpec.enableRemoteWriteReceiver: true` | MAY AFFECT | Prometheus 3.x supports this -- verify after upgrade |
| `prometheus.prometheusSpec.enableOTLPReceiver: true` | MAY AFFECT | Prometheus 3.x supports this -- verify after upgrade |
| `prometheus.prometheusSpec.storageSpec` | NOT affected | PVC template still supported in Prometheus 3.x |
| `prometheus.prometheusSpec.affinity` | NOT affected | Still supported |
| `prometheus.prometheusSpec.enableAdminAPI: true` | NOT affected | Still supported |
| `prometheus.route` (Gateway API) | NOT affected | Gateway API route config unchanged |
| `nodeExporter.enabled: false` | NOT affected | Not deployed |
| `kubeStateMetrics.enabled: false` | NOT affected | Not deployed |
| `kubernetesServiceMonitors.enabled: false` | NOT affected | Not deployed |

**Upgrade procedure:** ArgoCD will sync the new chart. CRDs are included (includeCRDs: true) so they update automatically. No manual steps required.

## Changelog

### 87.16.1 -> 87.17.0 Delta
- scrape kube-scheduler resource metrics (PR #7118)

### Major changes across 78.1.0 -> 87.17.0
- Prometheus-Operator: v0.86.0 -> v0.92.0
- Prometheus: v2.x -> v3.0.1+
- Various dependency bumps (kube-state-metrics, node-exporter, etc.)
- Metrics cardinality reduction defaults
- Removal of PSP and deprecated Ingress API support
- Grafana admin password now auto-generated (not affected -- grafana disabled)

## Source

https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.17.0
