### PR TITLE
chore: exclude immich namespace from Beyla instrumentation

### DIFF
--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -76,6 +76,7 @@ autoInstrumentation:
             - k8s_namespace: .
           exclude_services:
             - k8s_namespace: observability
+            - k8s_namespace: immich
             - exe_path: .*alloy.*|.*otelcol.*|.*beyla.*
         routes:
           patterns:


### PR DESCRIPTION
## Summary

Adds `immich` namespace to Beyla's exclusion list so its pods are not auto-instrumented by eBPF tracing.

**Change:**
- `apps/observability/k8s-monitoring-helm/values.yaml` — add `- k8s_namespace: immich` under `discovery.exclude_services`

Related: immich services should not be traced/instrumented by Beyla.