### PR TITLE
chore: exclude authentik namespace from Beyla instrumentation

### DIFF
--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -77,6 +77,7 @@ autoInstrumentation:
           exclude_services:
             - k8s_namespace: observability
             - k8s_namespace: immich
+            - k8s_namespace: authentik
             - exe_path: .*alloy.*|.*otelcol.*|.*beyla.*
         routes:
           patterns:


### PR DESCRIPTION
## Summary

Adds `authentik` namespace to Beyla's eBPF auto-instrumentation exclusion list.

**Change:**
```diff
 exclude_services:
   - k8s_namespace: observability
   - k8s_namespace: immich
+  - k8s_namespace: authentik
   - exe_path: .*alloy.*|.*otelcol.*|.*beyla.*
```