### PR TITLE
feat: enable Envoy access logs for Gateway API via CiliumGatewayClassConfig

### DIFF
--- a/apps/cilium/gateway-class-config.yaml
+++ b/apps/cilium/gateway-class-config.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumGatewayClassConfig
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  description: Cilium shared gateway config with access logging
+  telemetry:
+    accessLogs:
+      - format: JSON
+        json:
+          gateway: "%CILIUM_GATEWAY_NAMESPACE%/%CILIUM_GATEWAY_NAME%"
+          start_time: "%START_TIME%"
+          method: "%REQUEST_HEADER(:METHOD)%"
+          path: "%REQUEST_HEADER(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+          protocol: "%PROTOCOL%"
+          response_code: "%RESPONSE_CODE%"
+          response_flags: "%RESPONSE_FLAGS%"
+          bytes_received: "%BYTES_RECEIVED%"
+          bytes_sent: "%BYTES_SENT%"
+          duration: "%DURATION%"
+          authority: "%REQUEST_HEADER(:AUTHORITY)%"
+          upstream_host: "%UPSTREAM_HOST%"

--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ip-pool.yaml
   - announcement-policy.yaml
   - gateway.yaml
+  - gateway-class-config.yaml
 
 patches:
   - target:
@@ -26,3 +27,16 @@ patches:
       - op: add
         path: /data/bpf-filter-riority
         value: "2"
+  - target:
+      kind: GatewayClass
+      name: cilium
+      group: gateway.networking.k8s.io
+      version: v1
+    patch: |-
+      - op: add
+        path: /spec/parametersRef
+        value:
+          group: cilium.io
+          kind: CiliumGatewayClassConfig
+          name: cilium
+          namespace: kube-system


### PR DESCRIPTION
## Summary

Enables structured JSON access logs for all Gateways managed by Cilium's Gateway API (built on Envoy), available since Cilium 1.19.x.

**Changes:**

1. **`apps/cilium/gateway-class-config.yaml`** (new) — `CiliumGatewayClassConfig` resource defining JSON-format access logs with key request fields (method, path, status, duration, upstream host, gateway identity, etc.)

2. **`apps/cilium/kustomization.yaml`** — add the new resource + a JSON patch that injects `spec.parametersRef` onto the Helm-created `GatewayClass` (no manual GatewayClass management)

**How it works:** The Helm chart still auto-creates the `GatewayClass` as before. Kustomize patches a `parametersRef` onto it that links to our `CiliumGatewayClassConfig`. No values.yaml changes needed.

**Access log format (per Envoy access log entry):**
```json
{
  "gateway": "kube-system/cilium-shared-gateway",
  "start_time": "2026-07-06T10:10:13.622Z",
  "method": "GET",
  "path": "/api/endpoint",
  "protocol": "HTTP/1.1",
  "response_code": 200,
  "response_flags": "-",
  "bytes_received": 0,
  "bytes_sent": 178,
  "duration": 8,
  "authority": "app.g2net.xyz",
  "upstream_host": "10.244.0.221:9080"
}
```

Logs go to the `cilium-envoy` container stdout in `kube-system` — queryable via Loki.