### PR TITLE
fix: use standard Envoy format operators for Gateway API access logs

### DIFF
--- a/apps/cilium/gateway-class-config.yaml
+++ b/apps/cilium/gateway-class-config.yaml
@@ -12,16 +12,16 @@ spec:
         json:
           gateway: "%CILIUM_GATEWAY_NAMESPACE%/%CILIUM_GATEWAY_NAME%"
           start_time: "%START_TIME%"
-          method: "%REQUEST_HEADER(:METHOD)%"
-          path: "%REQUEST_HEADER(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+          method: "%REQ(:METHOD)%"
+          path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
           protocol: "%PROTOCOL%"
           response_code: "%RESPONSE_CODE%"
           response_flags: "%RESPONSE_FLAGS%"
           bytes_received: "%BYTES_RECEIVED%"
           bytes_sent: "%BYTES_SENT%"
           duration: "%DURATION%"
-          authority: "%REQUEST_HEADER(:AUTHORITY)%"
+          authority: "%REQ(:AUTHORITY)%"
           upstream_host: "%UPSTREAM_HOST%"
         targets:
           - HTTP
-        text: "[%START_TIME%] \"%REQUEST_HEADER(:METHOD)% %REQUEST_HEADER(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESPONSE_HEADER(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQUEST_HEADER(X-FORWARDED-FOR)%\" \"%REQUEST_HEADER(USER-AGENT)%\" \"%REQUEST_HEADER(X-REQUEST-ID)%\" \"%REQUEST_HEADER(:AUTHORITY)%\" \"%UPSTREAM_HOST%\""
+        text: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\""


### PR DESCRIPTION
## Problem

After PRs #352 and #353, the Envoy listener for `cilium-shared-gateway` is continuously rejected with:

> `Not supported field in StreamInfo: REQUEST_HEADER`

The `%REQUEST_HEADER(...)%` and `%RESPONSE_HEADER(...)%` format operators are **Cilium-specific custom formatters not available in Cilium 1.19.6** — the bundled Envoy v1.36.9 only supports standard [Envoy format operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage).

No access logs are being generated as a result.

## Fix

Replace all non-standard operators with standard Envoy equivalents:

| Before | After |
|---|---|
| `%REQUEST_HEADER(:METHOD)%` | `%REQ(:METHOD)%` |
| `%REQUEST_HEADER(X-ENVOY-ORIGINAL-PATH?:PATH)%` | `%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%` |
| `%REQUEST_HEADER(:AUTHORITY)%` | `%REQ(:AUTHORITY)%` |
| `%RESPONSE_HEADER(X-ENVOY-UPSTREAM-SERVICE-TIME)%` | `%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%` |
| `%REQUEST_HEADER(X-FORWARDED-FOR)%` | `%REQ(X-FORWARDED-FOR)%` |
| `%REQUEST_HEADER(USER-AGENT)%` | `%REQ(USER-AGENT)%` |
| `%REQUEST_HEADER(X-REQUEST-ID)%` | `%REQ(X-REQUEST-ID)%` |

These affect both the `json` block and the `text` fallback format.

## After merge

Will verify:
- [ ] Envoy listener rejection stops
- [ ] JSON access log lines appear in `cilium-envoy` stdout
- [ ] Logs are queryable in Loki