### PR TITLE
chore(deps): pyroscope 1.15.1 → 2.1.1 (v2 architecture upgrade)

### DIFF
--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 1.15.1
+    version: 2.1.1
     releaseName: pyroscope
     valuesFile: values.yaml
 

--- a/apps/observability/pyroscope/values.yaml
+++ b/apps/observability/pyroscope/values.yaml
@@ -12,6 +12,15 @@ pyroscope:
                 operator: NotIn
                 values:
                   - pi
+  # Explicitly use filesystem backend (default in v2, but explicit is safer)
+  structuredConfig:
+    storage:
+      backend: filesystem
+
+architecture:
+  storage:
+    v1: false
+    v2: true
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
## What

Upgrade Pyroscope from v1 to v2 storage architecture: chart 1.15.1 → 2.1.1.

## Research

Read the [migration guide](https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/) and inspected the [v2 Helm chart source](https://github.com/grafana/pyroscope/tree/main/operations/pyroscope/helm/pyroscope).

Key findings for our homelab:

- **Filesystem IS the default storage backend** in v2 — confirmed by the v2.0 breaking change commit. No object storage needed.
- **Single-binary mode** (1 pod) + **ReadWriteOnce NFS volume** works fine — the `ReadWriteMany` warning is for multi-replica microservices mode only.
- v2 stores data at `/data/v2/shared` (subdirectory of the PVC mount), which coexists cleanly with any old v1 data at the root of `/data`.
- Port 4040 unchanged — no Grafana datasource or alloy-profiles URL changes needed.

## Changes

| File | Change |
|------|--------|
| `apps/observability/pyroscope/kustomization.yaml` | Bump chart version 1.15.1 → 2.1.1 |
| `apps/observability/pyroscope/values.yaml` | Added `structuredConfig.storage.backend: filesystem` and `architecture.storage.v1: false / v2: true` for explicit v2 config |

## Deployment Notes

When this deploys, the single-binary Pyroscope pod will restart with v2 storage:
- The existing PVC at `/mnt/fast/pyroscope` is reused.
- Old v1 data on the PVC is **not queryable** after the upgrade (it's a different storage format). It remains on disk but is ignored by v2.
- If you want to reclaim space from old v1 data, empty the PVC contents before the upgrade.

## Verification

- [ ] Pyroscope pod restarts and becomes healthy
- [ ] Profiles are queryable in Grafana (Explore → Pyroscope datasource)
- [ ] Profiles are still being ingested (check alloy-profiles logs for no errors)
- [ ] `kubectl logs -n observability -l app.kubernetes.io/instance=pyroscope` shows no startup errors
- [ ] The metastore raft initializes (log message: "entering leader state")