### PR TITLE
fix: apply k8sName() to configMapRef.name in main.jsonnet

### DIFF
--- a/apps/observability/grafana-resources/monitoring-mixins/main.jsonnet
+++ b/apps/observability/grafana-resources/monitoring-mixins/main.jsonnet
@@ -255,7 +255,7 @@ local dashboardResources(cfg) =
                   matchLabels: { dashboards: 'grafana' },
                 },
                 configMapRef: {
-                  name: cmName,
+                  name: k8sName(cmName),
                   key: fileName,
                 },
               },


### PR DESCRIPTION
### Root cause

The `dashboardResources` function in `main.jsonnet` generates both a ConfigMap and a GrafanaDashboard CR for each dashboard file. The ConfigMap `metadata.name` correctly uses `k8sName()` (lowercases, replaces dots with dashes), but the GrafanaDashboard's `configMapRef.name` used the raw `cmName` instead.

This caused a mismatch when upstream mixin dashboard filenames contained uppercase characters (e.g. `cilium-L3-policy.json`, `cilium-L7-proxy.json`):

- ConfigMap: `cilium-mixins-cilium-l3-policy` ✅ lowercased
- GrafanaDashboard CR ref: `cilium-mixins-cilium-L3-policy` ❌ uppercase

### Fix

Apply `k8sName()` to `configMapRef.name` so both resources always reference the same lowercased name.

The previously patched generated bundle (in #357) will regenerate correctly on next `make all`.

### Before/after

```diff
  configMapRef: {
-   name: cmName,
+   name: k8sName(cmName),
    key: fileName,
  },
```