### PR TITLE
chore: add Immich PostgreSQL database as Grafana datasource

### DIFF
--- a/apps/observability/grafana-resources/datasources.yaml
+++ b/apps/observability/grafana-resources/datasources.yaml
@@ -138,3 +138,32 @@ spec:
     editable: false
     url: http://pyroscope:4040
     uid: pyroscope-main
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: immich
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  valuesFrom:
+    - targetPath: "secureJsonData.password"
+      valueFrom:
+        secretKeyRef:
+          name: immich-database-app
+          namespace: immich
+          key: password
+  datasource:
+    name: Immich
+    type: postgres
+    access: proxy
+    url: immich-database-rw.immich.svc:5432
+    database: app
+    user: app
+    isDefault: false
+    editable: false
+    uid: immich-db
+    jsonData:
+      sslmode: disable
+      postgresVersion: 1600


### PR DESCRIPTION
Adds a PostgreSQL datasource for the Immich database (CloudNativePG) to Grafana.

**Datasource details:**
- Type: PostgreSQL
- Host: `immich-database-rw.immich.svc:5432`
- Database: `app`
- User: `app`
- TLS: disabled (cluster-internal)
- UID: `immich-db`

**Secrets:** Password is pulled from the existing `immich-database-app` secret (auto-generated by CloudNativePG) via `valuesFrom` — no new secret needed.

**Use case:** Direct SQL querying of Immich data for custom dashboards — total asset count, storage usage per user, etc.