### PR TITLE
chore: add Immich PostgreSQL database as Grafana datasource

### DIFF
--- a/apps/immich/grafana-datasource.yaml
+++ b/apps/immich/grafana-datasource.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: immich
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  valuesFrom:
+    - targetPath: "secureJsonData.password"
+      valueFrom:
+        secretKeyRef:
+          name: immich-database-app
+          key: password
+  datasource:
+    name: Immich
+    type: postgres
+    access: proxy
+    url: immich-database-rw.immich.svc:5432
+    database: app
+    user: app
+    isDefault: false
+    editable: false
+    uid: immich-db
+    jsonData:
+      sslmode: disable
+      postgresVersion: 1600

--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   - pvc.yaml
   - httproute.yaml
   - sealed-secret.yaml
+  - grafana-datasource.yaml
   - backup-pod-config.yaml
   - backup-schedule.yaml

--- a/apps/observability/grafana-resources/datasources.yaml
+++ b/apps/observability/grafana-resources/datasources.yaml
@@ -138,32 +138,3 @@ spec:
     editable: false
     url: http://pyroscope:4040
     uid: pyroscope-main
----
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDatasource
-metadata:
-  name: immich
-spec:
-  instanceSelector:
-    matchLabels:
-      dashboards: "grafana"
-  valuesFrom:
-    - targetPath: "secureJsonData.password"
-      valueFrom:
-        secretKeyRef:
-          name: immich-database-app
-          namespace: immich
-          key: password
-  datasource:
-    name: Immich
-    type: postgres
-    access: proxy
-    url: immich-database-rw.immich.svc:5432
-    database: app
-    user: app
-    isDefault: false
-    editable: false
-    uid: immich-db
-    jsonData:
-      sslmode: disable
-      postgresVersion: 1600


### PR DESCRIPTION
Replaces the previous approach (#362) that had a cross-namespace secret reference issue.

**Approach:** Place the GrafanaDatasource in the `immich` app (namespace: immich) so it can reference the `immich-database-app` secret that CloudNativePG auto-generates. No sealed secret needed — the password stays in sync automatically.

**Changes:**
- `apps/observability/grafana-resources/datasources.yaml` — reverted (removed the immich entry that referenced `namespace: immich` which the CRD schema rejected)
- `apps/immich/grafana-datasource.yaml` — new PostgreSQL datasource in the immich namespace
- `apps/immich/kustomization.yaml` — registered the new file