### PR TITLE
fix: add allowCrossNamespaceImport to Immich GrafanaDatasource

### DIFF
--- a/apps/immich/grafana-datasource.yaml
+++ b/apps/immich/grafana-datasource.yaml
@@ -4,6 +4,7 @@ kind: GrafanaDatasource
 metadata:
   name: immich
 spec:
+  allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
       dashboards: "grafana"


### PR DESCRIPTION
The Grafana instance is in the `observability` namespace but the datasource is in `immich`. Without `allowCrossNamespaceImport: true`, the operator skips it with `NoMatchingInstance`.\n\nSee [Grafana Operator docs — cross namespace](https://grafana.github.io/grafana-operator/docs/examples/common_options/crossnamespace/readme/)