### PR TITLE
fix(observability): Immich datasource default DB + Grafana image-renderer token

### DIFF
--- a/apps/immich/grafana-datasource.yaml
+++ b/apps/immich/grafana-datasource.yaml
@@ -27,5 +27,9 @@ spec:
     jsonData:
       sslmode: disable
       postgresVersion: 1600
+      # The grafana-postgresql-datasource plugin reads the default database from
+      # jsonData.database; the legacy top-level `database` field above only feeds
+      # the backend, so without this the panel editor errors "no default database".
+      database: app
     secureJsonData:
       password: ${password}

--- a/apps/observability/grafana/sealed-secret.yaml
+++ b/apps/observability/grafana/sealed-secret.yaml
@@ -54,3 +54,23 @@ spec:
       creationTimestamp: null
       name: loki-operational-plugin-provisioning
 
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: "true"
+  creationTimestamp: null
+  name: grafana-image-renderer-token
+  namespace: observability
+spec:
+  encryptedData:
+    token: AgBQ8tkm5h8bou59lkn4ie8bRjiBDWzCeor4trNpMAI+XNG4kIRNtyBR5J+HzeqX1jZBCA+zSuMt5hwV2GhvdQWDvHsH+PSXTddScbCL8/+rUPjrKRYIIhUJYU4PVXzkG0XdvluvspABVP7DLzUAfy1JEOs6b8bH2QXsQLadTd9RtSBVSHOwW9FJLpug1ReBMfitosjNMnYaVVRwMeeq8hfpS2llEWCxdKou1mA2rb/zkROLWPuAJAUZG0EzF12HBwGadq1J36IKCI4vH+8aMPd8DFulzBarpIRzZGqeurwOzX55u+s9N6XLTde+sHMR4SV7YJqiCWpInMMty3RO69i5wDLYXbthXEyRr69jR6cOSAEtZJnDUApN1KbwoQ2izmxDv2pva83QQ1nkgZeyN40o8GIaoWLdFEusoFvXh85fHen+YgcCrS3KW3ySS7meD5qLyy09OIJ24c2LDtELT1XSR6IdiXlrgrLfZtF/jyXFq1UQjnEm5qjw3IsTnxjbaMA3QNnrc/IfTaAshucmuEe+sTPGzLWpq4ObXmLnMKcHrz8IgbVx37/PM3x+tfVJXdxICKk0LNhX5QJUHZfpLJoSDtyMOxIDTNg0L4pzbuHfNfmLNf/vbzq4+IzEh+flhs4TbOtWN+SSOYsKxKIDLoPgTVFsBQZCXYId68RYRIxEs1lmTd6QYi6UNom0viNXDfVKt9KSiyUu2cN+ryTMpwWw5KTHxZbmz64t/KeTbdB0rKHGR3PucEXU
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/cluster-wide: "true"
+      creationTimestamp: null
+      name: grafana-image-renderer-token
+      namespace: observability
+    type: Opaque

--- a/apps/observability/grafana/values.yaml
+++ b/apps/observability/grafana/values.yaml
@@ -30,6 +30,10 @@ extraSecretMounts:
     defaultMode: 0440
     mountPath: /etc/secrets/auth_generic_oauth
     readOnly: true
+  - name: loki-operational-plugin-provisioning
+    mountPath: /etc/grafana/provisioning/plugins
+    secretName: loki-operational-plugin-provisioning
+    readOnly: true
 
 hostAliases:
  - ip: "192.168.0.51"
@@ -73,12 +77,12 @@ admin:
 
 imageRenderer:
   enabled: true
-
-extraSecretMounts:
-  - name: loki-operational-plugin-provisioning
-    mountPath: /etc/grafana/provisioning/plugins
-    secretName: loki-operational-plugin-provisioning
-    readOnly: true
+  # Pin the shared Grafana<->renderer auth token to a stable SealedSecret.
+  # The chart otherwise generates it with randAlphaNum guarded by `lookup`, which
+  # returns empty under ArgoCD's `helm template` (no cluster access) — so the token
+  # was regenerated on every render, and the two pods drifted to mismatched tokens,
+  # causing renders to fail with 401 Unauthorized.
+  existingSecret: grafana-image-renderer-token
 
 nodeSelector:
   kubernetes.io/hostname: n200


### PR DESCRIPTION
## Summary

Fixes discovered while building the **Immich Library** Grafana dashboard. Three distinct bugs, all in git so ArgoCD reconciles them:

### 1. Immich panels showed "No data" — missing `jsonData.database`
`apps/immich/grafana-datasource.yaml` runs on the `grafana-postgresql-datasource` plugin, which reads the default database from **`jsonData.database`**. Only the legacy top-level `database: app` was set — that feeds the backend proxy but not the frontend query editor, so every panel errored with *"You do not currently have a default database configured for this data source"* and rendered No data. Added `database: app` under `jsonData`.

### 2. Grafana image rendering failed (401 → 500)
`GF_RENDERING_RENDERER_TOKEN` (Grafana) and `AUTH_TOKEN` (renderer) both read the chart-generated `grafana-image-renderer` Secret, whose token uses `randAlphaNum` guarded by `lookup`. Under ArgoCD's `helm template` `lookup` returns empty, so the token regenerates on every render and the two pods drift to **mismatched tokens** → renderer rejects Grafana → snapshots 500. Pinned to a stable SealedSecret (`grafana-image-renderer-token`) via `imageRenderer.existingSecret`.

### 3. Latent SSO-breaking bug — duplicate `extraSecretMounts`
`values.yaml` defined `extraSecretMounts` **twice**; YAML last-key-wins silently dropped the OAuth secret mount (`/etc/secrets/auth_generic_oauth`). The running pod predates the change, so it still works — but the **next rollout would break Authentik SSO** (`$__file{...}` would 404). Merged both mounts into one list.

## Verification
- `kubectl kustomize apps/observability/grafana --enable-helm` → both env vars reference the pinned secret, grafana pod keeps **both** mounts, churning chart secret no longer generated.
- Datasource fix confirmed against the live `grafana-postgresql-datasource` schema.
- Renderer token mismatch confirmed by hashing both env vars in the running pods.

## Rollout notes
- SealedSecret + deployment change roll out together; both pods restart on the same stable token.
- Datasource change triggers a Grafana Operator reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)