### PR TITLE
chore: trigger fresh ArgoCD sync to clear stale SSA error

### DIFF
--- a/apps/observability/grafana-resources/datasources.yaml
+++ b/apps/observability/grafana-resources/datasources.yaml
@@ -138,3 +138,4 @@ spec:
     editable: false
     url: http://pyroscope:4040
     uid: pyroscope-main
+# trigger-sync-001


### PR DESCRIPTION
No-op change to trigger ArgoCD to re-sync grafana-resources, clearing a stale ServerSideApply error state for a GrafanaDatasource that doesn't exist in the source.