### PR TITLE
fix: reduce descheduler schedule from every 2m to every 15m

### DIFF
--- a/apps/descheduler/cronjob-patch.yaml
+++ b/apps/descheduler/cronjob-patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: descheduler-cronjob
   namespace: kube-system
 spec:
-  schedule: "*/2 * * * *"
+  schedule: "*/15 * * * *"
   jobTemplate:
     spec:
       template:

--- a/apps/observability/grafana-resources/datasources.yaml
+++ b/apps/observability/grafana-resources/datasources.yaml
@@ -138,4 +138,3 @@ spec:
     editable: false
     url: http://pyroscope:4040
     uid: pyroscope-main
-# trigger-sync-001


### PR DESCRIPTION
Every 2 minutes is too aggressive for LowNodeUtilization and RemovePodsViolatingNodeTaints strategies. The constant pod churn cascades into:\n- NodeNotReady events (n200 went down for 1m during evictions)\n- Cilium/alloy operator crash-loops from leader election timeouts\n- API server error budget burn\n\nEvery 15 minutes is still responsive enough for rebalancing.