### PR TITLE
chore(deps): immich v2.5.6 → v2.6.3

### DIFF
--- a/apps/immich/values.yaml
+++ b/apps/immich/values.yaml
@@ -3,7 +3,7 @@ controllers:
     containers:
       main:
         image:
-          tag: v2.5.6
+          tag: v2.6.3
 
 service:
   main:


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| immich (image tag) | v2.5.6 | → | v2.6.3 | GREEN |

## Breaking Changes / Upgrade Notes

No breaking changes. This bump stays within the Immich v2.x line and updates the pinned image tag to match the chart's default appVersion (v2.6.3). The Immich chart version 0.12.0 already ships with appVersion v2.6.3 — the values.yaml was pinning an older patch.

## Impact on Current Setup

- **No breaking changes introduced** — minor patch bump within the same major version.
- The chart's default appVersion is already v2.6.3; this change only removes a stale pin.
- No CRD, API, or config schema changes between v2.5.6 and v2.6.3.

## Changelog

### v2.6.0 (2026-03-19)
350+ commits over 6 weeks. Bug fixes and enhancements across the app. Prepares for the next major release (v3).

### v2.6.1 (2026-03-19)
- Fixed a failed migration issue on the mobile app when the URL Switching feature is used
- Fallback to email when name is empty
- Ignore errors deleting untitled album
- Wrap long album title on web

### v2.6.2 (2026-03-24)
- Fixed bug where shared link errors on upload
- Fixed URL switching feature with external URLs
- Fixed "add to album" selection not including shared albums
- Fixed search filter issues on mobile

### v2.6.3 (2026-03-26)
- Removed upload timeout on mobile
- Prevent horizontal scroll bar in asset viewer side panel on web
- Fixed shifting motion image button on web

## Source

- https://github.com/immich-app/immich/releases/tag/v2.6.3
- Immich chart 0.12.0 ships with appVersion v2.6.3
