### PR TITLE
chore(deps): itarmykit-headless 2.2.8 → 2.2.10

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: itarmykit
-          image: registry.download.itarmy.com.ua/itarmykit-headless:2.2.8
+          image: registry.download.itarmy.com.ua/itarmykit-headless:2.2.10
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| itarmykit-headless | 2.2.8 | → | 2.2.10 | GREEN |

## Breaking Changes / Upgrade Notes

No breaking changes. This is a bug-fix/stability release:
- Fixes Max no longer collapsing after a traffic peak
- Eliminates false mid-band restart (healthy Hold no longer killed by median plateau restart)
- Max startup keeps a live proxy (no longer overwrites live proxy.enc with empty stub)
- Fixes the Linux headless 2.2.7 packaging bug (status=203/EXEC after auto-update)

## Impact on Current Setup

- **No config changes needed** — same command-line args, environment variables, and volume mounts.
- **No new capabilities or dependencies** — pure bugfix release.
- **Image source unchanged**: `registry.download.itarmy.com.ua/itarmykit-headless`.

## Changelog

### 2.2.10 (2026-07-15) — BaseTool Engine 1.4.2
- **Fixed**: Max no longer collapses after a traffic peak. Kit repairs hollow mid-band shells and keeps useful traffic alive instead of trapping in Bootstrap.
- **Fixed**: No false mid-band restart. A healthy mid-band Hold is no longer killed by a "median plateau" restart that wipes pairs.
- **Fixed**: Max startup keeps a live proxy. Packaged Max applies the correct socket rail and never overwrites a live `proxy.enc` with an empty stub.
- **Historical fix**: Resolves the Linux headless/Docker 2.2.7 packaging bug (`status=203/EXEC` after auto-update).

### 2.2.9 (2026-05-20)
- Intermediate release with minor improvements.

## Source

- https://itarmy.com.ua/kit-release/?lang=en
- https://download.itarmy.com.ua/releases/2.2.10/
- Registry: `registry.download.itarmy.com.ua/itarmykit-headless:2.2.10`
