### PR TITLE
chore(deps): itarmykit-headless 2.2.8 → 2.3.0

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: itarmykit
-          image: registry.download.itarmy.com.ua/itarmykit-headless:2.2.8
+          image: registry.download.itarmy.com.ua/itarmykit-headless:2.3.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| itarmykit-headless | 2.2.8 | → | 2.3.0 | YELLOW |

## Breaking Changes / Upgrade Notes

ITArmyKit 2.3.0 brings several architectural improvements:

- **One pressure plan**: Rust now owns how many routes stay active and why (no silent second planner).
- **Docker on Debian 13**: Official headless image moves to `debian:trixie-slim` with fail-closed CVE/SBOM gate.
- **CPU/bandwidth caps are your policy**: Workers and pressure scale from chosen limits; named presets stay migration-only.

## Impact on Current Setup

- **One pressure plan**: NOT affected - this is an internal engine change, no config changes needed.
- **Docker on Debian 13**: NOT affected - the image runs identically; Debian 13 as base is transparent.
- **CPU/bandwidth caps**: NOT affected - the deployment already sets explicit limits via env vars (cpuLimitPercent=30, bandwidthLimitMbps=100). These are fully compatible.
- **All fixes are runtime improvements**: Traffic recovery after peak, weak CPU scaling, statistics credit - all internal.
- **No CRD, API, or config schema changes** between 2.2.x and 2.3.0.

## Changelog

### 2.3.0 (2026)
- **New**: Clearer pair progress - main shows how many targets have a working route vs scouting coverage.
- **New**: Smarter route discovery - Kit prioritizes targets without a route, stale backups, and diversity gaps.
- **New**: One pressure plan - Rust controls route activation levels; no silent second planner.
- **New**: CPU/bandwidth caps are your policy - workers and pressure scale from configured limits.
- **New**: Docker on Debian 13 - official headless image moves to debian:trixie-slim.
- **Fixed**: Traffic no longer dies after a peak - Kit keeps active pressure routes after burst recovery.
- **Fixed**: Honest Main rates - Useful, Kit on-wire, and Host outbound are three separate numbers.
- **Fixed**: Weak CPUs no longer peg at 100% - on 2-3 core machines, caps scale workers appropriately.
- **Fixed**: Statistics credit delayed periods - valid late uploads no longer vanish.
- **Fixed**: No false thrash after a proxy peak - recovery no longer restart-loops under Adaptive freeze.

## Source

- https://download.itarmy.com.ua/
