### PR TITLE
chore(deps): pyroscope 2.1.1 -> 2.1.2

### DIFF
--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 2.1.1
+    version: 2.1.2
     releaseName: pyroscope
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| pyroscope | 2.1.1 | → | 2.1.2 | GREEN |

## Breaking Changes / Upgrade Notes

Pyroscope chart 2.1.2 is a patch release with no breaking changes. The chart update includes a source commit bump to the pyroscope-2.1.2 tag on the grafana/pyroscope repo.

No CRD changes, no API version removals, no default value changes.

## Impact on Current Setup

- **No breaking changes**: patch-level bump across the same minor version line.
- **Values schema unchanged**: no keys added, removed, or renamed since 2.1.1.
- **Sub-chart behavior unchanged**: no new dependencies or sub-charts.
- **Upgrade is transparent**: single-binary mode unaffected.

## Changelog

### pyroscope-2.1.2
- A horizontally scalable, highly available, multi-tenant continuous profiling database.
- Source commit: https://github.com/grafana/pyroscope/commit/80c4d217e19ec8b12d91500d2076011ab750bb6b
- Tag on source: https://github.com/grafana/pyroscope/releases/tag/pyroscope-2.1.2

## Source

- https://github.com/grafana/helm-charts/releases/tag/pyroscope-2.1.2
