### PR TITLE
chore(deps): kube-prometheus-stack 87.17.0 -> 87.19.0

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 87.17.0
+    version: 87.19.0
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 87.17.0 | → | 87.19.0 | YELLOW |

## Breaking Changes / Upgrade Notes

**87.18.0 — kube-state-metrics v8 chart update:**
- The kube-state-metrics Helm chart was updated to a new major version (v8).
- This is a **dependency chart version bump**, not a kube-state-metrics app version bump.
- The `collectors` key was renamed to `resources` in the kube-state-metrics chart.
- Dropped support for Helm v2 (Helm v3 required).
- Since kube-prometheus-stack manages kube-state-metrics internally and the user does not directly configure it, this is transparent.

**87.19.0 — grafana dependency updated to v12.8.0:**
- Updates the bundled Grafana instance to v12.8.0 chart, which includes Grafana app v13.1.1.
- See the separate grafana chart bump PR for detailed breaking changes analysis on Grafana v13.

## Impact on Current Setup

- **kube-state-metrics chart v8 (`collectors` → `resources` rename)**: NOT affected — the user's kube-prometheus-stack values.yaml does not directly configure kube-state-metrics collectors/resources. The stack manages this internally.
- **Helm v3 requirement**: NOT affected — ArgoCD uses Helm v3 natively.
- **Bundled Grafana update to v12.8.0**: NOT affected — the user runs a SEPARATE grafana instance (apps/observability/grafana/). The bundled grafana in kube-prometheus-stack is used only for the monitoring stack dashboards.
- **No CRD changes**: The kube-prometheus-stack chart version change is across patch/minor versions, not a re-packaging or CRD change in the 87.x line.

## Changelog

### 87.18.0
- [CI] Update actions/checkout action to v7.0.1
- [kube-prometheus-stack] Update Helm release kube-state-metrics to v8 (major chart version bump for KSM dependency)
  - kube-state-metrics collectors key renamed to resources
  - Dropped Helm v2 support

### 87.18.1
- [kube-prometheus-stack] Update kube-prometheus-stack dependency non-major updates

### 87.19.0
- [kube-prometheus-stack] Update Helm release grafana to v12.8.0 (bundled grafana dependency)

## Source

- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.19.0
- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.18.0
- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.17.0
