### PR TITLE
chore(deps): grafana 12.7.2 -> 12.8.0

### DIFF
--- a/apps/observability/grafana/kustomization.yaml
+++ b/apps/observability/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: grafana
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 12.7.2
+    version: 12.8.0
     releaseName: grafana
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| grafana | 12.7.2 | → | 12.8.0 | YELLOW |

## Breaking Changes / Upgrade Notes

This bump spans two chart releases:
- **12.7.3** — bumps the bundled Grafana app image from v12.x to **v13.1.1**
- **12.8.0** — minor bats dependency update

### Grafana v13.0 Breaking Changes

From the [Grafana v13.0 what's new](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-0/):

1. **Removal of deprecated @grafana/ui components**: `Graph`, `GraphWithLegend`, `GraphContextMenu`, `graphTimeFormat`, etc. removed. These were deprecated since 2023.
2. **RBAC enforcement tightened**: Custom roles, Terraform-managed roles, and role provisioning get stricter enforcement. Roles with `annotations:*` wildcard scopes or `datasources:uid:<uid>` with `global=true` need migration.
3. **Dynamic dashboards GA**: New layout engine default-on. Existing dashboards migrated automatically on open — no manual steps.

### Grafana v13.1 Changes

From the [Grafana v13.1 what's new](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-1/):
- New features and GA promotions only — no breaking changes in v13.1.

## Impact on Current Setup

- **Removal of deprecated @grafana/ui components (`Graph`, etc.)**: NOT affected — the user does not maintain custom plugins or panels that import from `@grafana/ui`. The plugins installed (grafana-strava-datasource, grafana-image-renderer, grafana-lokioperational-app) are maintained upstream and should be compatible with v13.
- **RBAC enforcement tightened**: NOT affected — the user does not manage custom Grafana RBAC roles, Terraform roles, or role provisioning. The deployment uses OAuth with Authentik for access control.
- **Dynamic dashboards GA (default-on)**: NOT affected — dashboards are migrated automatically on first open. No config changes needed.
- **Grafana Loki Operational plugin**: MAY AFFECT — the `grafana-lokioperational-app` plugin should be verified against Grafana v13 compatibility. This is a plugin maintained by Grafana Labs, so v13 support is expected.
- **Grafana image renderer plugin**: NOT affected — the renderer is a separate sidecar process, not a frontend plugin. It is not affected by React/v13 UI changes.
- **OAuth with Authentik**: NOT affected — OAuth generic OAuth config (auth.generic_oauth) is stable across v13. No breaking changes in OAuth flow.
- **Provisioning / ConfigMap structure**: NOT affected — the user's grafana.ini config structure (server, auth, users, recording_rules) uses stable keys unchanged since v11.

### Key config values checked against v13 defaults
| Setting | State | Verdict |
|---|---|---|
| `server.domain` | explicitly set | NOT affected |
| `server.root_url` | explicitly set | NOT affected |
| `auth.generic_oauth.*` | 8 keys explicitly set | NOT affected |
| `extraSecretMounts` | explicitly set | NOT affected |
| `persistence.enabled=true` | explicitly set | NOT affected |
| `plugins` (3 plugins) | explicitly set | Verify plugin v13 compatibility |
| `imageRenderer.enabled=true` | explicitly set | NOT affected |

## Changelog

### grafana-12.7.3
- Updated bundled Grafana image to v13.1.1 (major app version bump)

### grafana-12.8.0
- [grafana] Update docker.io/bats/bats Docker tag to v1.14.0

## Source

- https://github.com/grafana-community/helm-charts/releases/tag/grafana-12.8.0
- https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-0/
- https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-1/
- https://grafana.com/docs/grafana/latest/upgrade-guide/upgrade-v13.0/
