### PR TITLE
chore: disable beyla and pyroscope

### DIFF
--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -20,9 +20,7 @@ destinations:
       enabled: false
     traces:
       enabled: true
-  - name: pyroscope
-    type: pyroscope
-    url: http://pyroscope:4040
+  # pyroscope disabled — removed from cluster
 
 clusterMetrics:
   enabled: true
@@ -58,6 +56,7 @@ annotationAutodiscovery:
 autoInstrumentation:
   enabled: true
   beyla:
+    enabled: false
     metricsTuning:
       excludeMetrics:
         - http_client_request_body_size.*

--- a/argocd/apps/pyroscope.yaml
+++ b/argocd/apps/pyroscope.yaml
@@ -1,25 +1,26 @@
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: pyroscope
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
-spec:
-  project: default
-  destination:
-    namespace: observability
-    server: https://kubernetes.default.svc
-  source:
-    path: apps/observability/pyroscope
-    repoURL: https://github.com/gedulis12/homelab
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      allowEmpty: true
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
+# pyroscope disabled
+#---
+#apiVersion: argoproj.io/v1alpha1
+#kind: Application
+#metadata:
+#  name: pyroscope
+#  namespace: argocd
+#  finalizers:
+#    - resources-finalizer.argocd.argoproj.io
+#spec:
+#  project: default
+#  destination:
+#    namespace: observability
+#    server: https://kubernetes.default.svc
+#  source:
+#    path: apps/observability/pyroscope
+#    repoURL: https://github.com/gedulis12/homelab
+#    targetRevision: HEAD
+#  syncPolicy:
+#    automated:
+#      allowEmpty: true
+#      prune: true
+#      selfHeal: true
+#    syncOptions:
+#      - CreateNamespace=true
+#      - ServerSideApply=true


### PR DESCRIPTION
Disabling two unused components:

- **Beyla**: set `autoInstrumentation.beyla.enabled: false` in k8s-monitoring chart. Keeps `autoInstrumentation.enabled: true` for future use but stops the eBPF agent from running.
- **Pyroscope**: commented out the ArgoCD Application manifest. The `resources-finalizer` + `prune: true` will cascade-delete the Pyroscope StatefulSet, PVC, and all associated resources on next sync. Also removed the pyroscope destination from k8s-monitoring (URL would be dead).