### PR TITLE
chore: disable profiling (no pyroscope destination)

### DIFF
--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -117,7 +117,7 @@ prometheusOperatorObjects:
 # pprof - profiles.grafana.com/cpu.scheme: scheme
 # pprof - profiles.grafana.com/cpu.container: container
 profiling:
-  enabled: true
+  enabled: false
 
 alloy-receiver:
   enabled: true


### PR DESCRIPTION
The previous PR (#378) removed the pyroscope destination from k8s-monitoring, but `profiling.enabled: true` still expects a profiles-capable destination. The chart validation blocks manifest generation:\n\n    No destinations found that can accept profiles from Profiling\n\nThis causes ArgoCD to sit at `Unknown` sync status with a ComparisonError, so neither the Beyla disable nor any other change in k8s-monitoring-helm can be applied.\n\nFix: set `profiling.enabled: false` since there's no pyroscope endpoint to send profiles to.