### PR TITLE
chore: disable orphaned alloy-profiles collector

### DIFF
--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -123,7 +123,7 @@ alloy-receiver:
   enabled: true
 
 alloy-profiles:
-  enabled: true
+  enabled: false
 
 alloy-metrics:
   enabled: true


### PR DESCRIPTION
PR #379 disabled profiling (no pyroscope destination), but the `alloy-profiles` collector was still enabled. The chart validation now blocks with:\n\n    The alloy-profiles collector is enabled, but there are no enabled features that will use it.\n\nFix: set `alloy-profiles.enabled: false`. This should be the last piece — after this, the chart should render cleanly and ArgoCD will apply the Beyla disable + profiling disable + alloy-profiles disable in one sync.