### PR TITLE
chore: disable autoInstrumentation entirely

### DIFF
--- a/apps/observability/k8s-monitoring-helm/values.yaml
+++ b/apps/observability/k8s-monitoring-helm/values.yaml
@@ -54,9 +54,8 @@ annotationAutodiscovery:
   scrapeInterval: 30s
 
 autoInstrumentation:
-  enabled: true
+  enabled: false
   beyla:
-    enabled: false
     metricsTuning:
       excludeMetrics:
         - http_client_request_body_size.*


### PR DESCRIPTION
The k8s-monitoring chart v3.8.11 has a template bug: `beyla-config.yaml` references `beyla.fullname` from the beyla subchart even when `beyla.enabled: false`. The subchart isn't loaded when disabled, so the template fails.\n\nSetting `autoInstrumentation.enabled: false` skips the entire block cleanly and fixes this error:\n\n    template: k8s-monitoring/templates/beyla-config.yaml:6:11: \n    error calling include: template: no template "beyla.fullname" associated with template "gotpl"\n\nThis eliminates the last manifest generation error. After merge, ArgoCD should render and sync successfully, applying: Beyla off, profiling off, alloy-profiles off.