### PR TITLE
fix: stop scraping services without prometheus metrics

### DIFF
--- a/apps/immich/values.yaml
+++ b/apps/immich/values.yaml
@@ -9,6 +9,7 @@ service:
   main:
     annotations:
       k8s.grafana.com/scrape: "true"
+      k8s.grafana.com/scrape.portName: "metrics-api"
 
 immich:
   persistence:

--- a/apps/k8s-gateway/kustomization.yaml
+++ b/apps/k8s-gateway/kustomization.yaml
@@ -11,3 +11,10 @@ helmCharts:
     version: 3.7.2
     releaseName: excoredns
     valuesFile: values.yaml
+
+patches:
+  - path: metrics-port-patch.yaml
+    target:
+      kind: Service
+      name: excoredns-k8s-gateway
+      version: v1

--- a/apps/k8s-gateway/metrics-port-patch.yaml
+++ b/apps/k8s-gateway/metrics-port-patch.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/ports/-
+  value:
+    name: metrics
+    port: 9153
+    targetPort: metrics
+    protocol: TCP

--- a/apps/k8s-gateway/values.yaml
+++ b/apps/k8s-gateway/values.yaml
@@ -4,9 +4,12 @@ watchedResources:
   - "Ingress"
   - "Service"
   - "HTTPRoute"
+# DNS-only service (port 53) + prometheus metrics on port 9153.
+# The chart enables the prometheus CoreDNS plugin but doesn't expose the port.
+# Scrape annotation on the DNS port always times out — target only port 9153.
 service:
   loadBalancerIP: 192.168.0.53
   annotations:
     k8s.grafana.com/scrape: "true"
-
+    k8s.grafana.com/scrape.port: "9153"
 replicaCount: 3

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -36,10 +36,39 @@ patches:
       name: argocd-rbac-cm
       version: v1
     path: rbac-cm-patch.yaml
+  # Remove blanket scrape annotation - most argocd services don't serve metrics
+  # Target only services with real prometheus endpoints:
   - target:
       version: v1
       kind: Service
-      labelSelector: app.kubernetes.io/part-of=argocd
+      name: argocd-repo-server
+    patch: |-
+      - op: add
+        path: /metadata/annotations/k8s.grafana.com~1scrape
+        value: "true"
+      - op: add
+        path: /metadata/annotations/k8s.grafana.com~1scrape.portName
+        value: metrics
+  - target:
+      version: v1
+      kind: Service
+      name: argocd-metrics
+    patch: |-
+      - op: add
+        path: /metadata/annotations/k8s.grafana.com~1scrape
+        value: "true"
+  - target:
+      version: v1
+      kind: Service
+      name: argocd-server-metrics
+    patch: |-
+      - op: add
+        path: /metadata/annotations/k8s.grafana.com~1scrape
+        value: "true"
+  - target:
+      version: v1
+      kind: Service
+      name: argocd-notifications-controller-metrics
     patch: |-
       - op: add
         path: /metadata/annotations/k8s.grafana.com~1scrape


### PR DESCRIPTION
Alloy's annotation autodiscovery scrapes `/metrics` on **every port** of any Service annotated with `k8s.grafana.com/scrape: "true"`. Several services have this annotation but either don't serve metrics or don't expose the correct port, causing 10s scrape timeouts every cycle.

**Changes:**

| File | What | Why |
|---|---|---|
| `argocd/kustomization.yaml` | Replaced `labelSelector` blanket patch with targeted patches per metrics service | Dex server, redis, argocd-server have no /metrics — caused ~50s of timeouts per 30s cycle |
| `apps/immich/values.yaml` | Added `scrape.portName: metrics-api` | Immich serves metrics on 8081, but the main HTTP port (2283) was also scraped unnecessarily |
| `apps/k8s-gateway/values.yaml` | Re-added scrape annotation with `scrape.port: 9153` | Pod exposes CoreDNS metrics at 9153, but the service only had port 53 (DNS) — scrape hit DNS port and timed out |
| `apps/k8s-gateway/metrics-port-patch.yaml` + `kustomization.yaml` | Added JSON patch to expose port 9153 on the service | Without exposing the port in the service, Alloy can't reach the metrics endpoint |

**Still scraped (correctly):** `argocd-repo-server` (port `metrics` 8084), `argocd-metrics`, `argocd-server-metrics`, `argocd-notifications-controller-metrics`, `k8s-gateway` (port 9153), `immich` (port `metrics-api` 8081).

**No longer scraped:** `argocd-dex-server` (all 3 ports), `argocd-redis`, `argocd-server` (ports 80/443).