### PR TITLE
chore(deps): authentik 2026.5.5 → 2026.5.6

### DIFF
--- a/apps/authentik/kustomization.yaml
+++ b/apps/authentik/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   - name: authentik
     repo: https://charts.goauthentik.io
     namespace: authentik
-    version: 2026.5.5
+    version: 2026.5.6
     releaseName: authentik
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| authentik | 2026.5.5 | → | 2026.5.6 | GREEN |

## Breaking Changes / Upgrade Notes

Patch release — no breaking changes. Part of the 2026.5.x stable release line.

## Impact on Current Setup

- No breaking changes — patch bump only.
- Current values.yaml (postgresql disabled, external secrets, HTTPRoute) is unaffected.
- All existing config keys remain valid.

## Changelog

**2026.5.5 → 2026.5.6**: Patch release with bug fixes and dependency updates.
- Updated PostgreSQL chart dependency
- Various bug fixes and dependency bumps

See the full changelog at https://github.com/goauthentik/helm/releases

## Source

https://github.com/goauthentik/helm/releases/tag/authentik-2026.5.6
