### PR TITLE
chore(deps): loki 18.5.1 → 18.5.2

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.5.1
+    version: 18.5.2
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.5.1 | → | 18.5.2 | GREEN |

## Breaking Changes / Upgrade Notes

Patch release on the Grafana Community fork — no breaking changes. This chart is already on the grafana-community fork.

## Impact on Current Setup

- Patch bump only — no values changes needed.
- Deployment uses SingleBinary mode with filesystem storage — unaffected.
- All existing config keys (loki.ui.enabled, pattern_ingester, gateway route, etc.) remain valid.
- The repo URL is already on `grafana-community.github.io/helm-charts` — no migration needed.

## Changelog

**18.5.1 → 18.5.2**: Patch release with bug fixes.
- Bug fixes and dependency updates
- Loki app version remains at 3.7.x

Full changelog: https://github.com/grafana-community/helm-charts/releases

## Source

https://artifacthub.io/packages/helm/grafana-community/loki/18.5.2
