### PR TITLE
chore(deps): pyroscope 2.1.1 → 2.2.0

### DIFF
--- a/apps/observability/pyroscope/kustomization.yaml
+++ b/apps/observability/pyroscope/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: pyroscope
     repo: https://grafana.github.io/helm-charts
     namespace: observability
-    version: 2.1.1
+    version: 2.2.0
     releaseName: pyroscope
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| pyroscope | 2.1.1 | → | 2.2.0 | YELLOW |

## Breaking Changes / Upgrade Notes

Minor version bump (2.1.x → 2.2.0). No breaking changes, but key changes to note:
- Helm chart now defaults to v2 storage architecture (already explicitly set in values.yaml)
- `extraObjects` support added for deploying extra K8s manifests
- Monitoring dashboards migrated to native histograms
- Various bug fixes and performance improvements

## Impact on Current Setup

- **V2 architecture default change**: NOT affected — values.yaml explicitly sets `architecture.storage.v1: false` and `architecture.storage.v2: true`, overriding any default change.
- **Alloy sub-chart enabled by default**: NOT affected — already explicitly set to `alloy.enabled: false`.
- **Filesystem storage config**: NOT affected — already set via `structuredConfig.storage.backend: filesystem`.
- **Persistence**: NOT affected — existingClaim and persistence config unchanged between versions.
- **No renamed or removed values**: All currently used values keys remain valid in 2.2.0.
- **No CRD changes**: Grafana Operator CRDs for GrafanaDashboard etc. are managed separately and not affected.

## Changelog

**2.1.1 → 2.2.0**:
- Added readiness checks for the distributor
- Added debug information list and delete APIs
- Added dataset index generation in segment writer
- Added metastore cache hit/miss metrics
- Added per-tenant limits for recording rules
- Updated Helm chart to default to v2 storage architecture
- Added `extraObjects` support for extra K8s manifests
- Migrated monitoring dashboards to native histograms
- Fixed out-of-bounds panic in `clearAddresses`
- Fixed nil matcher handling for recording rule upserts
- Fixed Helm chart rendering for `volumeClaimTemplates`
- Various other bug fixes

## Source

https://github.com/grafana/pyroscope/releases/tag/v2.2.0
