### PR TITLE
fix: detect Immich backup rotation instead of counting

### DIFF
--- a/apps/immich/backup-pod-config.yaml
+++ b/apps/immich/backup-pod-config.yaml
@@ -18,9 +18,9 @@ spec:
 
               API_URL="http://immich-server.immich.svc.cluster.local:2283/api"
 
-              echo "Fetching initial backup count..."
-              INITIAL_COUNT=$(curl -s -X GET "$API_URL/admin/database-backups" -H "x-api-key: $API_KEY" | grep -Eo 'filename' | wc -l)
-              echo "Initial database dump count: $INITIAL_COUNT"
+              echo "Fetching current backup fingerprint..."
+              BEFORE_HASH=$(curl -s -X GET "$API_URL/admin/database-backups" -H "x-api-key: $API_KEY" | grep -o '"filename":"[^"]*"' | sort | sha256sum)
+              echo "Current backup hash: $BEFORE_HASH"
 
               echo "Triggering new database backup..."
               curl -s -X POST "$API_URL/jobs" \
@@ -31,14 +31,14 @@ spec:
               echo "Waiting for the backup to complete..."
 
               MAX_RETRIES=30
-              RETRY_INTERVAL=60
+              RETRY_INTERVAL=10
               ATTEMPT=0
 
               while [ $ATTEMPT -lt $MAX_RETRIES ]; do
-                CURRENT_COUNT=$(curl -s -X GET "$API_URL/admin/database-backups" -H "x-api-key: $API_KEY" | grep -Eo 'filename' | wc -l)
+                AFTER_HASH=$(curl -s -X GET "$API_URL/admin/database-backups" -H "x-api-key: $API_KEY" | grep -o '"filename":"[^"]*"' | sort | sha256sum)
 
-                if [ "$CURRENT_COUNT" -gt "$INITIAL_COUNT" ]; then
-                  echo "Success: Backup completed! Count increased from $INITIAL_COUNT to $CURRENT_COUNT."
+                if [ "$AFTER_HASH" != "$BEFORE_HASH" ]; then
+                  echo "Success: New backup detected!"
                   exit 0
                 fi
 


### PR DESCRIPTION
## Problem

The Immich prune job's init container (k8up `PodConfig`) gets stuck in a loop — it triggers a database backup via the Immich API, then polls for the backup count to increase. But **Immich keeps exactly 15 backups**: when a new one is created, the oldest is pruned. The count stays at 15 forever.

Result: the init container polls for 30 minutes, hits timeout, exits with error, and the pod restarts. Seen 3 restart cycles so far.

## Root Cause

The API `GET /api/admin/database-backups` always returns exactly 15 items because Immich rotates old backups out. Counting matches of `filename` in the response yields an unchanging number.

## Fix

Instead of comparing counts, compute a **sha256 fingerprint of all filenames** in the backup list before and after triggering the backup. If any backup was rotated in/out (which always happens on a successful backup), the fingerprint changes.

Also reduced poll interval from 60s → 10s (backups complete in ~30s) so the init container exits quickly on success.

## Verification

Tested against live cluster: the API returns exactly 15 backups, and a triggered backup completes in ~25s but rotates the list. The new fingerprint comparison correctly detects this.