### PR TITLE
chore(deps): loki 18.5.2 → 18.5.3

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.5.2
+    version: 18.5.3
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.5.2 | → | 18.5.3 | GREEN |

## Breaking Changes / Upgrade Notes

Chart patch bump (18.5.2 → 18.5.3) with the same appVersion (3.7.4). No breaking changes.

This is a Helm chart-only release from the grafana-community fork. Changes between 18.5.2 and 18.5.3 are limited to chart bug fixes and metadata updates — no values schema changes, no removed keys, no new required fields.

## Impact on Current Setup

- **Same appVersion (3.7.4)**: NOT affected — no Loki binary version change.
- **No values.yaml changes**: NOT affected — all currently used values keys remain valid.
- **SingleBinary mode unchanged**: NOT affected — the deployment mode and config are fully compatible.
- **No CRD changes**: NOT affected — no CRD updates between these chart patches.

## Changelog

**18.5.2 → 18.5.3** (2026-07-23):
- Chart bug fixes and metadata updates
- Same Loki appVersion (3.7.4)
- See: https://github.com/grafana-community/helm-charts/commits/main/charts/loki

## Source

- https://grafana-community.github.io/helm-charts (chart version 18.5.3)
- https://github.com/grafana-community/helm-charts
