### PR TITLE
chore(deps): itarmykit-headless 2.2.8 → 2.3.1

### DIFF
--- a/apps/itarmy/daemonset.yaml
+++ b/apps/itarmy/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: itarmykit
-          image: registry.download.itarmy.com.ua/itarmykit-headless:2.2.8
+          image: registry.download.itarmy.com.ua/itarmykit-headless:2.3.1
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| itarmykit-headless | 2.2.8 | → | 2.3.1 | YELLOW |

## Breaking Changes / Upgrade Notes

ITArmyKit 2.3.1 is a patch on 2.3.0 that fixes a packaging bug where Linux headless/Docker versions 2.2.7 could fail with `status=203/EXEC` after auto-update.

Compared to 2.2.8, the 2.3.x line brings:

- **One pressure plan**: Rust now owns how many routes stay active and why (no silent second planner).
- **Docker on Debian 13**: Official headless image moves to `debian:trixie-slim` with fail-closed CVE/SBOM gate.
- **CPU/bandwidth caps are your policy**: Workers and pressure scale from chosen limits; named presets stay migration-only.
- **Fixed**: Traffic no longer dies after a peak — Kit keeps active pressure routes after burst recovery.
- **Fixed**: Weak CPUs no longer peg at 100% — on 2-3 core machines, caps scale workers appropriately.
- **Fixed**: No false thrash after a proxy peak — recovery no longer restart-loops under Adaptive freeze.

## Impact on Current Setup

- **One pressure plan**: NOT affected — internal engine change, no config changes needed.
- **Docker on Debian 13**: NOT affected — the image runs identically; Debian 13 as base is transparent.
- **CPU/bandwidth caps**: NOT affected — the deployment already sets explicit limits via env vars (cpuLimitPercent=30, bandwidthLimitMbps=100). These are fully compatible.
- **status=203/EXEC fix from 2.3.0→2.3.1**: NOT affected — the deployment uses `IfNotPresent` pull policy and runs via `exec` command, so the Supervisor handles updates correctly.
- **No CRD, API, or config schema changes**: All fixes are runtime improvements.

## Changelog

### 2.3.1 (2026-07-21)
- **Fixed**: Max no longer collapses after a peak — Kit repairs hollow mid-band shells after burst.
- **Fixed**: No false mid-band restart — healthy mid-band Hold no longer killed by "median plateau" restart.
- **Fixed**: Max startup keeps a live proxy — correct socket rail applied, no empty `proxy.enc` stub.
- **Historical**: Fixes packaging bug from 2.2.7 that caused `status=203/EXEC` on auto-update for Linux headless/Docker.

### 2.3.0 (2026)
- **New**: One pressure plan — Rust controls route activation levels; no silent second planner.
- **New**: Smarter route discovery — Kit prioritizes targets without a route, stale backups, diversity gaps.
- **New**: CPU/bandwidth caps are your policy — workers and pressure scale from configured limits.
- **New**: Docker on Debian 13 — official headless image moves to `debian:trixie-slim`.
- **Fixed**: Traffic recovery after peak, honest Main rates, weak CPU scaling, statistics credit, no false proxy thrash.

## Source

- https://itarmy.com.ua/kit-release/?lang=en (official release page)
- https://download.itarmy.com.ua/releases/2.3.1/
