### PR TITLE
chore(deps): kube-prometheus-stack 87.19.0 → 87.19.1

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 87.19.0
+    version: 87.19.1
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 87.19.0 | → | 87.19.1 | GREEN |

## Breaking Changes / Upgrade Notes

Patch bump (87.19.0 → 87.19.1) with the same appVersion (v0.92.1). No breaking changes.

Changes are limited to dependency updates:
- **kube-webhook-certgen** 1.8.4 → 1.8.5 (patch bump)
- **kube-prometheus** digest update `174e45d` → `ce1ae0f` (non-functional metadata update)

No values schema changes, no removed keys, no new required fields, no CRD changes.

## Impact on Current Setup

- **Same appVersion (v0.92.1)**: NOT affected — no Prometheus/KSM binary version change.
- **No values.yaml changes**: NOT affected — all currently used values keys remain valid across this patch.
- **Grafana sub-chart disabled**: NOT affected — `grafana.enabled: false` explicitly set, no grafana-related dependency changes impact this deployment.
- **Alertmanager, NodeExporter, KSM disabled**: NOT affected — these are already disabled and none of the updated dependencies relate to them.
- **Prometheus storage/retention config**: NOT affected — `storageSpec` and `retention` are unchanged.
- **No CRD changes**: NOT affected — CRDs are unchanged between these chart patches.

## Changelog

**87.19.0 → 87.19.1** (2026-07-24):
- [kube-prometheus-stack] Update dependency non-major updates
  - kube-webhook-certgen 1.8.4 → 1.8.5
  - kube-prometheus digest 174e45d → ce1ae0f

Source: https://github.com/prometheus-community/helm-charts/pull/7132

## Source

- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.19.1
- https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/87.19.1
