### PR TITLE
chore(deps): it-tools :latest → 2024.10.22

### DIFF
--- a/apps/it-tools/deployment.yaml
+++ b/apps/it-tools/deployment.yaml
@@ -19,6 +19,6 @@ spec:
     spec:
       containers:
         - name: it-tools
-          image: corentinth/it-tools:latest
+          image: corentinth/it-tools:2024.10.22-7ca5933
           ports:
             - containerPort: 80


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| it-tools | `:latest` | → | `2024.10.22-7ca5933` | GREEN |

# Change
Pinned the container image from the floating `:latest` tag to the specific date-stamped version `2024.10.22-7ca5933`. This project uses date-based version tags rather than semver. The pinned tag matches the current `:latest` digest, enabling reproducible rollbacks.

# Source
- https://hub.docker.com/r/corentinth/it-tools/tags (tag 2024.10.22-7ca5933)
