### PR TITLE
chore(deps): thelounge :latest → 4.5.2

### DIFF
--- a/apps/thelounge/deployment.yaml
+++ b/apps/thelounge/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: thelounge
-          image: thelounge/thelounge:latest
+          image: thelounge/thelounge:4.5.2
           ports:
             - containerPort: 9000
           volumeMounts:


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| thelounge | `:latest` | → | `:4.5.2` | GREEN |

# Change
Pinned the container image from the floating `:latest` tag to the specific version `4.5.2`. The `:latest` tag was pointing at the 4.5.2 digest, so this is a no-op deployment that enables reproducible rollbacks.

# Source
- https://hub.docker.com/r/thelounge/thelounge/tags (tag 4.5.2, Jul 24 2026)
