### PR TITLE
chore(deps): freshrss :latest → 1.29.1-ls314

### DIFF
--- a/apps/freshrss/deployment.yaml
+++ b/apps/freshrss/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: freshrss
-          image: lscr.io/linuxserver/freshrss:latest
+          image: lscr.io/linuxserver/freshrss:1.29.1-ls314
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| freshrss | `:latest` | → | `1.29.1-ls314` | GREEN |

# Change
Pinned the container image from the floating `:latest` tag to the specific linuxserver build `1.29.1-ls314`. This pins to a specific immutable linuxserver build of FreshRSS, enabling reproducible rollbacks.

# Source
- https://hub.docker.com/r/linuxserver/freshrss/tags (tag 1.29.1-ls314)