### PR TITLE
chore(deps): linkding :latest → 1.45.0

### DIFF
--- a/apps/linkding/deployment.yaml
+++ b/apps/linkding/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: linkding
-          image: sissbruecker/linkding:latest
+          image: sissbruecker/linkding:1.45.0-plus
           ports:
             - containerPort: 9090
           volumeMounts:


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| linkding | `:latest` | → | `1.45.0-plus` | GREEN |

# Change
Pinned the container image from the floating `:latest` tag to the specific version `1.45.0-plus`. The `:latest` tag resolves to the plus variant. The pinned tag matches the current digest, enabling reproducible rollbacks.

# Source
- https://hub.docker.com/r/sissbruecker/linkding/tags (tag 1.45.0-plus)