### PR TITLE
chore(deps): qbittorrent :latest → 5.2.3_v2.0.13-ls469, busybox :latest → 1.38.0

### DIFF
--- a/apps/media/qbittorrent/deployment.yaml
+++ b/apps/media/qbittorrent/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: copy-config
-          image: busybox:latest
+          image: busybox:1.38.0
           command: ['sh', '-xe', '-c']
           args:
             - mkdir -pv /config/qBittorrent;
@@ -34,7 +34,7 @@ spec:
               mountPath: "/config"
       containers:
         - name: qbittorrent
-          image: lscr.io/linuxserver/qbittorrent:latest
+          image: lscr.io/linuxserver/qbittorrent:5.2.3_v2.0.13-ls469
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| qbittorrent | `:latest` | → | `5.2.3_v2.0.13-ls469` | GREEN |
| busybox (init) | `:latest` | → | `1.38.0` | GREEN |

# Change
Pinned images from floating `:latest` tags to specific immutable versions. This ensures reproducible deployments and straightforward rollbacks.

# Source
- https://hub.docker.com/r/linuxserver/qbittorrent/tags (tag 5.2.3_v2.0.13-ls469)
- https://hub.docker.com/_/busybox/tags (tag 1.38.0)