### PR TITLE
chore(deps): sonarr :latest -> 4.0.19.2979-ls320, busybox :latest -> 1.38.0

### DIFF
--- a/apps/media/sonarr/deployment.yaml
+++ b/apps/media/sonarr/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: copy-config
-          image: busybox:latest
+          image: busybox:1.38.0
           command: ['sh', '-xe', '-c']
           args:
             - cp -f -L -v /config-init/* /config/;
@@ -33,7 +33,7 @@ spec:
               mountPath: "/config"
       containers:
         - name: sonarr
-          image: lscr.io/linuxserver/sonarr:latest
+          image: lscr.io/linuxserver/sonarr:4.0.19.2979-ls320
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| sonarr | `:latest` | → | `4.0.19.2979-ls320` | GREEN |
| busybox (init) | `:latest` | → | `1.38.0` | GREEN |

# Change
Pinned the container images from floating `:latest` tags to specific versions. The sonarr image is pinned to the latest linuxserver build. The busybox init container is pinned to 1.38.0 which is the latest stable multi-arch release.

# Source
- https://hub.docker.com/r/linuxserver/sonarr/tags (tag 4.0.19.2979-ls320)
- https://hub.docker.com/_/busybox/tags (tag 1.38.0)