### PR TITLE
chore(deps): wallabag :latest → 2.6.14

### DIFF
--- a/apps/wallabag/deployment.yaml
+++ b/apps/wallabag/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: wallabag
-          image: wallabag/wallabag:latest
+          image: wallabag/wallabag:2.6.14
           ports:
             - containerPort: 80
           volumeMounts:


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| wallabag | `:latest` | → | `:2.6.14` | GREEN |

# Change
Pinned the container image from the floating `:latest` tag to the specific version `2.6.14`. The `:latest` tag was pointing at the 2.6.14 digest, so this is a no-op deployment that enables reproducible rollbacks.

# Source
- https://hub.docker.com/r/wallabag/wallabag/tags (tag 2.6.14, Oct 2025)
