### PR TITLE
chore(deps): homepage :latest -> v1.13.2

### DIFF
--- a/apps/homepage/deployment.yaml
+++ b/apps/homepage/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: homepage
-          image: "ghcr.io/gethomepage/homepage:latest"
+          image: "ghcr.io/gethomepage/homepage:v1.13.2"
           env:
             - name: HOMEPAGE_ALLOWED_HOSTS
               value: homepage.g2net.xyz


### PR DESCRIPTION
# Bump
| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| homepage | `:latest` | -> | `v1.13.2` | GREEN |

# Change
Pinned the container image from the floating `:latest` tag to the specific version `v1.13.2`. The pinned tag matches the current `:latest` digest, enabling reproducible rollbacks.

# Source
- https://github.com/gethomepage/homepage/releases/tag/v1.13.2