### PR TITLE
chore(deps): radarr :latest → 6.3.0.10514-ls312, busybox :latest → 1.38.0

### DIFF
--- a/apps/media/radarr/deployment.yaml
+++ b/apps/media/radarr/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: copy-config
-          image: busybox:latest
+          image: busybox:1.38.0
           command: ['sh', '-xe', '-c']
           args:
             - cp -f -L -v /config-init/* /config/;
@@ -33,7 +33,7 @@ spec:
               mountPath: "/config"
       containers:
         - name: radarr
-          image: lscr.io/linuxserver/radarr:latest
+          image: lscr.io/linuxserver/radarr:6.3.0.10514-ls312
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| radarr | `:latest` | → | `6.3.0.10514-ls312` | GREEN |
| busybox (init) | `:latest` | → | `1.38.0` | GREEN |

# Change
Pinned the container images from floating `:latest` tags to specific versions. The radarr image is pinned to the latest linuxserver build. The busybox init container is pinned to 1.38.0 (latest stable).

# Source
- https://hub.docker.com/r/linuxserver/radarr/tags (tag 6.3.0.10514-ls312)
- https://hub.docker.com/_/busybox/tags (tag 1.38.0)