### PR TITLE
chore(deps): jellyfin :latest → 10.11.11ubu2604-ls43, busybox :latest → 1.38.0

### DIFF
--- a/apps/media/jellyfin/deployment.yaml
+++ b/apps/media/jellyfin/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/hostname: n200
       initContainers:
         - name: copy-config
-          image: busybox:latest
+          image: busybox:1.38.0
           command: ['sh', '-xe', '-c']
           args:
             - cp -f -L -v /config-init/* /config/;
@@ -37,7 +37,7 @@ spec:
               mountPath: "/config"
       containers:
         - name: jellyfin
-          image: lscr.io/linuxserver/jellyfin:latest
+          image: lscr.io/linuxserver/jellyfin:10.11.11ubu2604-ls43
           securityContext:
             privileged: true
           env:


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| jellyfin | `:latest` | → | `10.11.11ubu2604-ls43` | GREEN |
| busybox (init) | `:latest` | → | `1.38.0` | GREEN |

# Change
Pinned container images from floating `:latest` tags to specific immutable versions.

# Source
- https://hub.docker.com/r/linuxserver/jellyfin/tags (tag 10.11.11ubu2604-ls43)
- https://hub.docker.com/_/busybox/tags (tag 1.38.0)