### PR TITLE
chore(deps): prowlarr :latest → 2.5.2.5491-ls155, busybox :latest → 1.38.0

### DIFF
--- a/apps/media/prowlarr/deployment.yaml
+++ b/apps/media/prowlarr/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: copy-config
-          image: busybox:latest
+          image: busybox:1.38.0
           command: ['sh', '-xe', '-c']
           args:
             - cp -f -L -v /config-init/* /config/;
@@ -33,7 +33,7 @@ spec:
               mountPath: "/config"
       containers:
         - name: prowlarr
-          image: lscr.io/linuxserver/prowlarr:latest
+          image: lscr.io/linuxserver/prowlarr:2.5.2.5491-ls155
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| prowlarr | `:latest` | → | `2.5.2.5491-ls155` | GREEN |
| busybox (init) | `:latest` | → | `1.38.0` | GREEN |

# Change
Pinned container images from floating `:latest` tags to specific immutable versions.

# Source
- https://hub.docker.com/r/linuxserver/prowlarr/tags (tag 2.5.2.5491-ls155)
- https://hub.docker.com/_/busybox/tags (tag 1.38.0)