### PR TITLE
chore(deps): immich backup pod alpine :latest → 3.23.5

### DIFF
--- a/apps/immich/backup-pod-config.yaml
+++ b/apps/immich/backup-pod-config.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
         - name: database-backup
-          image: alpine:latest
+          image: alpine:3.23.5
           command: ['sh', '-c']
           args:
             - |


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| alpine (immich backup) | `:latest` | → | `3.23.5` | GREEN |

# Change
Pinned the Alpine base image used by the Immich k8up database backup init container from the floating `:latest` tag to the specific version `3.23.5`. This ensures reproducible backup pod executions.

# Source
- https://hub.docker.com/_/alpine/tags (tag 3.23.5)