### PR TITLE
chore(deps): cloudflared :latest → 2026.7.3

### DIFF
--- a/apps/maistokainos/cf-tunnel.yaml
+++ b/apps/maistokainos/cf-tunnel.yaml
@@ -30,7 +30,7 @@ spec:
           - name: net.ipv4.ping_group_range
             value: "65532 65532"
       containers:
-        - image: cloudflare/cloudflared:latest
+        - image: cloudflare/cloudflared:2026.7.3
           name: cloudflared
           ports:
             - name: http


### PR DESCRIPTION
# Bump
| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cloudflared (cf-tunnel) | `:latest` | → | `2026.7.3` | GREEN |

# Change
Pinned the cloudflared tunnel image from the floating `:latest` tag to the specific date-versioned `2026.7.3`. The deployment already uses `--no-autoupdate` to prevent automatic updates, making the version pin consistent with that policy.

# Source
- https://hub.docker.com/r/cloudflare/cloudflared/tags (tag 2026.7.3)