### PR TITLE
chore(deps): loki 18.5.3 → 18.5.4

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.5.3
+    version: 18.5.4
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.5.3 | → | 18.5.4 | GREEN |

## Breaking Changes / Upgrade Notes

Minor non-major dependency update only (Renovate bot update). No breaking changes.

## Impact on Current Setup

No values schema changes. This is a routine dependency bump that updates internal chart dependencies (non-major). NOT affected — no configuration changes needed.

## Changelog

- Update loki dependency non-major updates (Renovate bot)

## Source

- https://github.com/grafana-community/helm-charts/releases/tag/loki-18.5.4
- https://github.com/grafana-community/helm-charts/compare/loki-18.5.3...loki-18.5.4
