### PR TITLE
chore(deps): alpine 3.23.5 → 3.24.1

### DIFF
--- a/apps/immich/backup-pod-config.yaml
+++ b/apps/immich/backup-pod-config.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
         - name: database-backup
-          image: alpine:3.23.5
+          image: alpine:3.24.1
           command: ['sh', '-c']
           args:
             - |


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| alpine (immich backup pod) | 3.23.5 | → | 3.24.1 | GREEN |

## Change

Updated the Alpine Linux base image used in the immich database backup init container from 3.23.5 to 3.24.1. This is a minor point release bump on the same stable branch line.

## Changelog

Alpine Linux 3.24.1 is the latest stable point release of the 3.24 branch, featuring security patches and bug fixes over 3.23.5.

## Source

- https://hub.docker.com/_/alpine/tags?name=3.24.1
- https://alpinelinux.org/posts/Alpine-3.24.1-released.html
