### PR TITLE
chore(deps): kube-prometheus-stack 87.19.1 → 87.19.2

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 87.19.1
+    version: 87.19.2
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 87.19.1 | → | 87.19.2 | GREEN |

## Breaking Changes / Upgrade Notes

Patch release with no breaking changes. Key changes:
- Updated Grafana chart dependency to v12.8.1
- CI workflow dependency updates (docker/login-action v4.5.1, helm-unittest v1.1.2)

## Impact on Current Setup

- **Grafana dependency bump**: NOT affected — kube-prometheus-stack uses its bundled Grafana as a chart dependency, while the homelab has a separate Grafana deployment managed independently (`apps/observability/grafana/`). No config changes needed.
- **CI tooling updates**: NOT affected — no local CI configuration references these tools.
- **No values schema changes**: All currently used values keys remain valid in 87.19.2.

## Changelog

**87.19.1 → 87.19.2**:
- [CI] Update docker/login-action action to v4.5.1
- [CI] Update dependency helm-unittest/helm-unittest to v1.1.2
- [kube-prometheus-stack] Update Helm release grafana to v12.8.1

## Source

https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.19.2
