### PR TITLE
chore(deps): grafana 12.8.0 → 12.8.1

### DIFF
--- a/apps/observability/grafana/kustomization.yaml
+++ b/apps/observability/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: grafana
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 12.8.0
+    version: 12.8.1
     releaseName: grafana
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| grafana | 12.8.0 | → | 12.8.1 | GREEN |

## Breaking Changes / Upgrade Notes

Patch release with no breaking changes:
- Added `helm-docs` web page for rendering chart documentation
- Added `grafana.ini` configuration documentation note
- CI workflow dependency updates

## Impact on Current Setup

- **helm-docs web page**: NOT affected — no local tooling depends on this.
- **grafana.ini note**: NOT affected — documentation only, no values schema change.
- **CI workflow updates**: NOT affected — no local CI references these workflows.
- **No values schema changes**: All currently used values keys remain valid in 12.8.1.

## Changelog

**12.8.0 → 12.8.1**:
- [CI] Update github-workflow dependency updates
- [ALL] Add helm-docs web page
- [grafana] Add grafana.ini configuration note

## Source

https://github.com/grafana-community/helm-charts/releases/tag/grafana-12.8.1
