### PR TITLE
chore(deps): freshrss 1.29.1-ls314 → 1.29.1-ls315

### DIFF
--- a/apps/freshrss/deployment.yaml
+++ b/apps/freshrss/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: freshrss
-          image: lscr.io/linuxserver/freshrss:1.29.1-ls314
+          image: lscr.io/linuxserver/freshrss:1.29.1-ls315
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| freshrss | 1.29.1-ls314 | → | 1.29.1-ls315 | GREEN |

## Breaking Changes / Upgrade Notes

No breaking changes. Same app version (FreshRSS 1.29.1), updated linuxserver base image build. This is a routine rebuild that pulls in the latest Alpine/Debian base image security patches from the linuxserver build infrastructure.

## Impact on Current Setup

- **Same app version**: NOT affected — no application config changes needed.
- **Base image rebuild**: NOT affected — linuxserver build tags are functionally identical across the same app version.
- **No values schema changes**: NOT applicable — this is a bare image tag, not a Helm chart.

## Changelog

**1.29.1-ls314 → 1.29.1-ls315**:
- Routine linuxserver base image rebuild with latest security patches.
- No application version change.

## Source

https://hub.docker.com/r/linuxserver/freshrss/tags?name=1.29.1-ls315
