### PR TITLE
chore(deps): grafana 12.8.0 → 12.9.0

### DIFF
--- a/apps/observability/grafana/kustomization.yaml
+++ b/apps/observability/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: grafana
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 12.8.0
+    version: 12.9.0
     releaseName: grafana
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| grafana | 12.8.0 | → | 12.9.0 | GREEN |

## Breaking Changes / Upgrade Notes

Minor version bump with no breaking changes:
- Refactored chart name extraction in CI workflow
- Updated `kiwigrid/k8s-sidecar` dependency to v2.9.0

## Impact on Current Setup

- **CI workflow refactor**: NOT affected — no local CI references chart name extraction.
- **k8s-sidecar update**: NOT affected — the grafana chart uses k8s-sidecar for dashboard/provisioning reload; the v2.9.0 update is backward-compatible.
- **No values schema changes**: All currently used values keys (`grafana.ini`, `extraSecretMounts`, `hostAliases`, `route`, `persistence`, `plugins`, `env`, `admin`, `imageRenderer`, `nodeSelector`, `testFramework`) remain valid in 12.9.0.

## Changelog

**12.8.0 → 12.9.0**:
- [CI] Refactor chart name extraction in CI workflow
- [grafana] Update kiwigrid/k8s-sidecar Docker tag to v2.9.0

## Source

https://github.com/grafana-community/helm-charts/releases/tag/grafana-12.9.0
