### PR TITLE
chore(deps): kube-prometheus-stack 87.19.1 → 87.20.0

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 87.19.1
+    version: 87.20.0
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 87.19.1 | → | 87.20.0 | GREEN |

## Breaking Changes / Upgrade Notes

Patch release with no breaking changes — only non-major dependency updates (Renovate bot).

## Impact on Current Setup

- **Non-major dependency updates**: NOT affected — these are internal chart dependency bumps with no values schema changes.
- **Grafana sub-chart**: NOT affected — the homelab's kube-prometheus-stack has `grafana.enabled: false` (Grafana is deployed separately).
- **Alertmanager**: NOT affected — `alertmanager.enabled: false`.
- **No values schema changes**: All currently used values keys (`prometheus.prometheusSpec.*`, `grafana.enabled: false`, `alertmanager.enabled: false`, etc.) remain valid in 87.20.0.

## Changelog

**87.19.1 → 87.20.0**:
- [kube-prometheus-stack] Update dependency non-major updates (Renovate bot)

## Source

https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.20.0
