### PR TITLE
chore(deps): loki 18.5.3 → 18.6.0

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.5.3
+    version: 18.6.0
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.5.3 | → | 18.6.0 | GREEN |

## Breaking Changes / Upgrade Notes

Minor version bump with no breaking changes:
- Updated `kiwigrid/k8s-sidecar` dependency to v2.9.0

## Impact on Current Setup

- **k8s-sidecar update**: NOT affected — the loki chart uses k8s-sidecar for config reloading; v2.9.0 is backward-compatible.
- **No values schema changes**: All currently used values keys (`loki.*`, `gateway`, `deploymentMode: SingleBinary`, `singleBinary.*`, `backend/read/write/ingester/querier replicas: 0`, etc.) remain valid in 18.6.0.
- **SingleBinary mode**: NOT affected — the deployment mode and config remain unchanged.

## Changelog

**18.5.3 → 18.6.0**:
- [loki] Update kiwigrid/k8s-sidecar Docker tag to v2.9.0

## Source

https://github.com/grafana-community/helm-charts/releases/tag/loki-18.6.0
