### PR TITLE
chore(deps): loki 18.5.3 → 18.7.0

### DIFF
--- a/apps/observability/loki/kustomization.yaml
+++ b/apps/observability/loki/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: loki
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 18.5.3
+    version: 18.7.0
     releaseName: loki
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| loki | 18.5.3 | → | 18.7.0 | GREEN |

## Breaking Changes / Upgrade Notes

The grafana-community/loki chart has no breaking changes between 18.5.3 and 18.7.0. Both releases are minor dependency bumps:
- 18.6.0: Bumped kiwigrid/k8s-sidecar to v2.9.0
- 18.7.0: Bumped kiwigrid/k8s-sidecar to v2.10.0

The last breaking change was in 18.0.0 (dashboard architecture changed to individual ConfigMaps, `cluster` label replaced by `app_instance`). This deployment already on 18.5.3 had those changes applied.

## Impact on Current Setup

- **k8s-sidecar bump (v2.9.0 → v2.10.0)**: NOT affected — no custom sidecar config in this deployment.
- **Dashboard architecture**: NOT affected — already on 18.x, no change between 18.5.3 and 18.7.0.
- **Monitoring block refactoring**: NOT affected — this deployment uses SingleBinary mode with minimal monitoring config.
- **Auth/gateway config**: NOT affected — no changes to auth_enabled, gateway, or route config in these versions.

## Changelog

### 18.6.0 (27 Jul 2026)
- kiwigrid/k8s-sidecar bumped to v2.9.0
- CI refactoring

### 18.7.0 (28 Jul 2026)
- kiwigrid/k8s-sidecar bumped to v2.10.0

## Source

- https://github.com/grafana-community/helm-charts/releases/tag/loki-18.6.0
- https://github.com/grafana-community/helm-charts/releases/tag/loki-18.7.0
