### PR TITLE
chore(deps): kube-prometheus-stack 87.19.1 → 87.21.0

### DIFF
--- a/apps/observability/prometheus/kustomization.yaml
+++ b/apps/observability/prometheus/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: kube-prometheus-stack
     repo: https://prometheus-community.github.io/helm-charts
     namespace: observability
-    version: 87.19.1
+    version: 87.21.0
     releaseName: kube-prometheus-stack
     includeCRDs: true
     valuesFile: kube-prometheus-stack-values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| kube-prometheus-stack | 87.19.1 | → | 87.21.0 | GREEN |

## Breaking Changes / Upgrade Notes

No breaking changes between 87.19.1 and 87.21.0. Both releases are dependency bumps:
- 87.20.0: Dependency non-major updates (Prometheus sub-chart, Grafana sub-chart, etc.)
- 87.21.0: Grafana sub-chart bumped from 12.8.1 to 12.10.0

## Impact on Current Setup

- **Grafana sub-chart bump (12.8.1 → 12.10.0)**: NOT affected — this deployment uses a separate standalone Grafana (grafana-community/grafana chart) rather than the bundled one.
- **kube-state-metrics v8 update**: NOT affected — kube-state-metrics is internally managed by the chart, no breaking changes between patch versions.
- **Prometheus sub-chart update**: NOT affected — dependency-only bump, no API changes.
- **CRDs**: NOT affected — the `includeCRDs: true` setting will pick up any CRD updates automatically.

## Changelog

### 87.20.0
- Dependency non-major updates (kube-state-metrics, prometheus, alertmanager sub-charts)

### 87.21.0
- Grafana sub-chart bumped from 12.8.1 to 12.10.0
- CI updates (docker/login-action v4.5.2)

## Source

- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.20.0
- https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-87.21.0
