### PR TITLE
chore(deps): grafana 12.8.0 → 12.10.0

### DIFF
--- a/apps/observability/grafana/kustomization.yaml
+++ b/apps/observability/grafana/kustomization.yaml
@@ -8,7 +8,7 @@ helmCharts:
   - name: grafana
     repo: https://grafana-community.github.io/helm-charts
     namespace: observability
-    version: 12.8.0
+    version: 12.10.0
     releaseName: grafana
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| grafana | 12.8.0 | → | 12.10.0 | GREEN |

## Breaking Changes / Upgrade Notes

No breaking changes between 12.8.0 and 12.10.0. Both releases are minor dependency bumps:
- 12.9.0: Bumped kiwigrid/k8s-sidecar to v2.9.0, CI refactoring
- 12.10.0: Bumped kiwigrid/k8s-sidecar to v2.10.0, CI updates (stale action v11, login action v4.5.2)

## Impact on Current Setup

- **k8s-sidecar bump (v2.9.0 → v2.10.0)**: NOT affected — this deployment uses `plugins` to install Grafana plugins (strava, image-renderer, lokioperational) via the sidecar, and the sidecar protocol is unchanged between these versions.
- **CI refactoring**: NOT affected — no chart functionality changes.
- **Auth/Domain config**: NOT affected — grafana.ini and OAuth config remain stable.
- **Image renderer**: NOT affected — no changes to image rendering dependencies.
- **Plugins**: NOT affected — the plugin provisioning sidecar continues to work.

## Changelog

### 12.9.0 (27 Jul 2026)
- kiwigrid/k8s-sidecar bumped to v2.9.0
- CI refactoring (chart name extraction)

### 12.10.0 (28 Jul 2026)
- kiwigrid/k8s-sidecar bumped to v2.10.0
- CI updates (actions/stale v11, docker/login-action v4.5.2)

## Source

- https://github.com/grafana-community/helm-charts/releases/tag/grafana-12.9.0
- https://github.com/grafana-community/helm-charts/releases/tag/grafana-12.10.0
