### PR TITLE
chore(deps): reflector 10.0.60 → 10.0.61

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -12,7 +12,7 @@ helmCharts:
   - name: reflector
     repo: https://emberstack.github.io/helm-charts
     namespace: cert-manager
-    version: 10.0.60
+    version: 10.0.61
     releaseName: reflector
 
 #patches:


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| reflector | 10.0.60 | → | 10.0.61 | GREEN |

## Breaking Changes / Upgrade Notes

No breaking changes. v10.0.61 is a CI/dependency-only bump:
- build(deps): bump actions/setup-dotnet from 5 to 6
- build(deps): bump actions/stale from 10 to 11
- Bump the all-dependencies group with 6 updates

## Impact on Current Setup

- **CI/dependency bumps only**: NOT affected — no functionality changes, no chart values changes, no API changes.
- **Reflector behavior**: NOT affected — the Kubernetes controller logic is unchanged.

## Changelog

- build(deps): bump actions/setup-dotnet from 5 to 6
- build(deps): bump actions/stale from 10 to 11
- Bump the all-dependencies group with 6 updates

## Source

- https://github.com/emberstack/kubernetes-reflector/releases/tag/v10.0.61
