### PR TITLE
chore(deps): cilium 1.19.6 -> 1.20.0

### DIFF
--- a/apps/cilium/kustomization.yaml
+++ b/apps/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.19.6
+    version: 1.20.0
     namespace: kube-system
     releaseName: cilium
     valuesFile: values.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cilium | 1.19.6 | → | 1.20.0 | YELLOW |

## Breaking Changes / Upgrade Notes

Cilium 1.20.0 includes several removals and deprecations documented in the [Upgrade Guide](https://docs.cilium.io/en/v1.20/operations/upgrade/#upgrade-notes):

- **Mutual Authentication (Beta)**: Deprecated, will be removed in a future release
- **Envoy Go Extensions (proxylib)**: Removed (deprecated since 1.18)
- **Kafka-aware network policies**: Removed
- **cilium.io/v2alpha1 CiliumNodeConfig API**: Removed (use v2 instead)
- **libnetwork integration (cilium-docker-plugin)**: Removed
- **Custom CNI configuration**: The behavior changed — verify CNI chaining config
- **Various deprecated flags removed**: `--ces-slice-mode`, `--node-port-algorithm`, `--node-port-mode`, `--enable-ipsec-encrypted-overlay`, `--enable-encryption-strict-mode`, `tofqdnsPreCache` etc.
- **Gateway API**: Moved from v1.4 to v1.6.1 (new capabilities, backward-compatible)
- **Metrics**: `vrouter` label removed, use `instance_name` instead

Full changelog: https://github.com/cilium/cilium/blob/v1.20/CHANGELOG.md

## Impact on Current Setup

- **Mutual Authentication**: NOT affected — no mutual auth configured in values.yaml
- **Envoy Go Extensions (proxylib)**: NOT affected — only standard Envoy proxy used (envoy.prometheus monitoring only)
- **Kafka-aware policies**: NOT affected — no Kafka network policies deployed
- **CiliumNodeConfig v2alpha1 removed**: NOT affected — repo uses CiliumL2AnnouncementPolicy v2alpha1 and CiliumGatewayClassConfig v2alpha1, which are different CRD types and remain available
- **libnetwork integration**: NOT affected — K3s cluster, no Docker plugin needed
- **Custom CNI config**: NOT affected — Cilium is the sole CNI provider
- **Deprecated flags**: NOT affected — none of the removed flags are set in values.yaml
- **Gateway API v1.4→v1.6.1**: NOT affected — existing HTTPRoute, Gateway resources use v1 API, backward-compatible
- **Metrics label change (vrouter→instance_name)**: NOT affected — no scrape jobs consuming vrouter metric label

## Changelog

Cilium 1.20.0 is a major release with 2,660+ new commits. Key highlights:

- **Gateway API v1.6.1**: Support for Gateway API 1.6.1 with new capabilities
- **ListenerSets (Delegate Gateway Listeners)**: Application teams can manage their own listeners on shared Gateways
- **BackendTLSPolicy**: Encrypt traffic between Gateway and application backends
- **TCPRoute and UDPRoute**: Gateway API support for non-HTTP services
- **External Authorization**: HTTPRoute auth via external services (GEP-1494)
- **L2 Announcements**: Now GA (graduated from alpha)
- **BGP Control Plane**: Various enhancements
- **Network performance improvements**: eBPF optimizations

## Source

- https://github.com/cilium/cilium/releases/tag/v1.20.0
- https://docs.cilium.io/en/v1.20/operations/upgrade/
