### PR TITLE
chore(deps): cert-manager v1.21.0 -> v1.21.1

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.21.0/cert-manager.yaml
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.21.1/cert-manager.yaml
   - cluster-issuer.yaml
   - sealed-secret.yaml
   - certificate.yaml


### PR DESCRIPTION
## Bump

| Component | Current | → | Target | Risk |
|---|---|---|---|---|
| cert-manager | v1.21.0 | → | v1.21.1 | GREEN |

## Breaking Changes / Upgrade Notes

v1.21.1 is a patch release with bug fixes and dependency updates. No breaking changes.

## Impact on Current Setup

- **Certificate renewal.policy=Disabled panic fix**: NOT affected — no Certificates use `spec.renewal.policy: Disabled`
- **Secret informer event fix (log spam regression)**: NOT affected — improvement, no config change needed
- **Issuer stuck at Ready=False when DNS-01 Secret created after Issuer**: NOT affected — improvement, no config change needed
- **Gateway API Helm example fix (gatewayAPI.enabled typo)**: NOT affected — the commented example in values.yaml was cosmetic only

## Changelog

- Fix controller panic when Certificate has `spec.renewal.policy: Disabled`
- Fix Issuer/ClusterIssuer stuck at `Ready=False/InvalidSolver` after missing ACME DNS-01 solver Secret is created
- Fix log spam and dropped Secret informer events for non-cert-manager Secrets (regression in 1.21.0)
- Fix commented Gateway API config example in Helm values (`gatewayAPI.enable` → `gatewayAPI.enabled`)
- Bump `golang.org/x/text` to v0.40.0 (security vulnerability fix)
- Bump `google.golang.org/grpc` to v1.82.1 (security vulnerability fix)
- Bump `github.com/google/cel-go` to v0.29.0 (security vulnerability fix)
- Bump `go.opentelemetry.io/otel` to v1.44.0 (security vulnerability fix)
- Update distroless base images

## Source

- https://github.com/cert-manager/cert-manager/releases/tag/v1.21.1
