### PR TITLE
chore(deps): immich chart 0.12.0 → 0.13.1 (OCI)

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -6,9 +6,9 @@ namespace: immich
 
 helmCharts:
   - name: immich
-    repo: https://immich-app.github.io/immich-charts
+    repo: oci://ghcr.io/immich-app/immich-charts
     namespace: immich
-    version: 0.12.0
+    version: 0.13.1
     releaseName: immich
     valuesFile: values.yaml
 


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| immich (Helm chart) | 0.12.0 | -> | 0.13.1 | YELLOW |

## Breaking Changes / Upgrade Notes

The immich Helm chart migrated from the deprecated HTTP repo to **OCI-only publishing** starting at v0.13.0 ([release notes](https://github.com/immich-app/immich-charts/releases/tag/immich-0.13.0)):

- **BREAKING: HTTP helm repo removed / no longer receiving updates** — chart is now published via OCI at `oci://ghcr.io/immich-app/immich-charts`. The kustomize `repo` URL must change or the bump silently picks up a stale 0.12.x chart.
- **BREAKING: values schema rework (#382)** — bjw-s common library structure retained, but defaults changed (e.g. `valkey.enabled` now defaults to `false`).
- Chart is now signed with cosign (#332) and packages README/CHANGELOG for ArtifactHub (#379).

## Impact on Current Setup

Verified against the 0.13.1 OCI chart (`helm show values` + `values.schema.json` + templates):

- **Repo URL change**: AFFECTED — updated in this PR (`https://immich-app.github.io/immich-charts` -> `oci://ghcr.io/immich-app/immich-charts`). ArgoCD v3.1.0 runs kustomize with `--enable-helm` (kustomize 5.x), which supports OCI helm repos.
- **`controllers.main.containers.main.image.tag`**: NOT affected — same key location in 0.13.x. Repo sets `v2.5.6`; image tag bump handled separately (v3.1.0 PR).
- **`immich.persistence.library.existingClaim: immich-library`**: NOT affected — same path, still required (template `checks.yaml` validates it). Present in values.yaml.
- **`valkey.enabled: true`**: NOT affected — explicitly set in values.yaml (in-chart valkey with data persistence disabled), overrides new `false` default.
- **`server.persistence.quicksync` hostPath (/dev/dri)**: NOT affected — `server` is a full bjw-s common value set (`$ref: #/$defs/common`), arbitrary persistence keys supported.
- **`machine-learning.persistence.cache.enabled: false`**: NOT affected — same structure.
- **`immich.metrics.enabled: true`**: NOT affected — same path.

## Changelog

- **0.13.0** (2026-07-03): OCI-only publishing via release-please; values schema rework (#382); cosign chart signing; README/CHANGELOG packaged into chart.
- **0.13.1** (2026-07-03): Bugfix — quote changelog entries in artifacthub.io/changes annotation.

## Source

- https://github.com/immich-app/immich-charts/releases/tag/immich-0.13.1
- https://github.com/immich-app/immich-charts/releases/tag/immich-0.13.0
- OCI chart verified: `helm pull oci://ghcr.io/immich-app/immich-charts/immich --version 0.13.1` (digest sha256:b8e890d0d9804759c6b6f3e5f9a850512ca09b9ccc6d137a2f85cbf761981bd1)
