### PR TITLE
chore(deps): immich v2.5.6 → v3.1.0

### DIFF
--- a/apps/immich/values.yaml
+++ b/apps/immich/values.yaml
@@ -3,7 +3,7 @@ controllers:
     containers:
       main:
         image:
-          tag: v2.5.6
+          tag: v3.1.0
 
 service:
   main:


### PR DESCRIPTION
## Bump

| Component | Current | -> | Target | Risk |
|---|---|---|---|---|
| immich (image tag) | v2.5.6 | -> | v3.1.0 | YELLOW |

## Breaking Changes / Upgrade Notes

Immich v3.0.0 (prereq for v3.1.0) includes breaking changes documented in the [v3 Migration Guide](https://immich.app/blog/v3-migration):

- **pgvecto.rs removed**: Support for the pgvecto.rs vector extension has been dropped. `DB_VECTOR_EXTENSION=pgvecto.rs` now throws an error.
- **Environment variables removed**: `IMMICH_MACHINE_LEARNING_PING_TIMEOUT`, `MACHINE_LEARNING_PRELOAD__CLIP`, and `MACHINE_LEARNING_PRELOAD__FACIAL_RECOGNITION` have been removed or split.
- **Machine learning**: numpy now requires x86-64-v2 microarchitecture on x86 CPUs.
- **OAuth**: Insecure HTTP requests no longer permitted by default.
- **Metrics**: Underscore in metric names replaced with dots.
- **API endpoints**: Several deprecated endpoints removed (e.g. `GET /server/theme`, `POST /assets/exists`).
- **Error responses**: Migration from class-validator to Zod changes error response format.

## Impact on Current Setup

Cross-referenced against `apps/immich/values.yaml` and the app config:

- **pgvecto.rs removed**: NOT affected — this deployment already uses vectorchord (cloudnative-vectorchord), not pgvecto.rs.
- **Environment variables removed**: NOT affected — none of the removed env vars are set in values.yaml (only DB_* and IMMICH_LOG_FORMAT).
- **ML numpy x86 requirement**: NOT affected — homelab runs on ARM64 (n200 node).
- **OAuth changes**: NOT affected — OAuth is not configured for immich.
- **Metrics names**: NOT affected — no dashboards consume immich metrics (annotation-based scraping only).
- **API endpoint changes**: NOT affected — no external API consumers.
- **Error response changes**: NOT affected — no third-party tools using the API directly.

## Changelog

### v2.6.x (Mar 2026)
- v2.6.0: 350+ commits, bug fixes and enhancements across the app
- v2.6.1: Fixed migration issue on mobile, fallback to email when name empty
- v2.6.2: Fixed shared link upload errors, URL switching with external URLs
- v2.6.3: Removed upload timeout on mobile, fixed UI issues

### v3.0.0 (Jul 2, 2026)
- Major version release with breaking changes (see above)
- New release channel option (Release Candidate / Stable)
- Various internal refactors and API changes

### v3.0.1 (Jul 2, 2026)
- Fixes albums not showing up in mobile app

### v3.0.2 (Jul 9, 2026)
- Bug fixes from v3.0.0 release
- Additional filter for workflows

### v3.0.3 (Jul 15, 2026)
- Bug fixes
- F-Droid repo update
- LivePhotos background upload fix
- Memory search date validation fix

### v3.1.0 (Jul 29, 2026)
- Upload wakelock (web)
- Undo archive (web)
- Filter assets by server filepath (workflows)
- Filter assets by EXIF metadata (workflows)
- Quick navigate to maintenance page (web)
- OIDC role claim sync improvements (OAuth)
- Invalidate sessions on password reset (admin-cli)

## Source

- https://github.com/immich-app/immich/releases/tag/v3.1.0
- https://immich.app/blog/v3-migration
